### PR TITLE
ci: release spring-boot bumps as chore on the patch lane

### DIFF
--- a/.github/workflows/bump-spring.yml
+++ b/.github/workflows/bump-spring.yml
@@ -43,22 +43,8 @@ jobs:
         with:
           version: ${{ needs.latest-version.outputs.spring-boot }}
           compare-to: ${{ needs.current-version.outputs.spring-boot }}
-      # 依 Spring Boot 升級幅度決定 PR 的 conventional commit 類型: 中版號 (或主版號) 升級用 feat, 僅升小版號用 fix
-      - name: Resolve commit type
-        id: commit-type
-        env:
-          CURRENT: ${{ needs.current-version.outputs.spring-boot }}
-          LATEST: ${{ needs.latest-version.outputs.spring-boot }}
-        run: |
-          # 去掉修訂號, 只比 major.minor
-          if [ "${CURRENT%.*}" = "${LATEST%.*}" ]; then
-            echo "type=fix" >> "$GITHUB_OUTPUT"
-          else
-            echo "type=feat" >> "$GITHUB_OUTPUT"
-          fi
     outputs:
       comparison-result: ${{ steps.semver-compare.outputs.comparison-result }}
-      commit-type: ${{ steps.commit-type.outputs.type }}
 
   bump-spring:
     runs-on: ubuntu-latest
@@ -90,8 +76,8 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "${{ needs.compare-version.outputs.commit-type }}: bump spring-boot from ${{ needs.current-version.outputs.spring-boot }} to ${{ needs.latest-version.outputs.spring-boot }}"
-          title: "${{ needs.compare-version.outputs.commit-type }}: bump spring-boot from ${{ needs.current-version.outputs.spring-boot }} to ${{ needs.latest-version.outputs.spring-boot }}"
+          commit-message: "chore: bump spring-boot from ${{ needs.current-version.outputs.spring-boot }} to ${{ needs.latest-version.outputs.spring-boot }}"
+          title: "chore: bump spring-boot from ${{ needs.current-version.outputs.spring-boot }} to ${{ needs.latest-version.outputs.spring-boot }}"
           committer: bot 👾 <bot-noreply@softleader.com.tw>
           author: bot 👾 <bot-noreply@softleader.com.tw>
           body: >-

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,7 +7,20 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "skip-snapshot": true
+      "skip-snapshot": true,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "chore", "section": "Miscellaneous Chores"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "style", "section": "Styles", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "build", "section": "Build System", "hidden": true},
+        {"type": "ci", "section": "Continuous Integration", "hidden": true}
+      ]
     }
   }
 }


### PR DESCRIPTION
## 變更內容

讓每日 `bump-spring` 的 Spring Boot 升級走 **chore → patch** 發版車道（kapok 式「依賴維護一律 patch」慣例），取代原本依版號差決定 `feat`/`fix` 的邏輯。兩處改動是一組耦合：

- **`.github/workflows/bump-spring.yml`** — 移除 delta-driven 的 `Resolve commit type` 步驟與 `commit-type` output，commit-message 與 title 固定為 `chore: bump spring-boot from X to Y`。
- **`.release-please-config.json`** — 新增 `changelog-sections`,讓 `feat`/`fix`/`perf`/`revert` + `chore`/`refactor` 可見,其餘(`docs`/`style`/`test`/`build`/`ci`)隱藏。

## 為什麼兩者要一起改

`chore` 在 release-please 預設(含 Maven 內建 `CHANGELOG_SECTIONS`)是隱藏的。若只改 workflow 不開 `changelog-sections`,spring 的 `chore:` PR 會渲染空 changelog → **切不出 release**。現在雙閘門對齊:`chore` 可見 → 開 release PR(gate 2)→ patch 升版(gate 1)。

## 行為取捨

Spring Boot **minor** 升級(如 3.5 → 3.6)以前切一個 specification-mapper **minor**(feat),現在切 **patch**(chore)。`bump-spring` 的 `boot-version: "~3.x"` 把自動升級鎖在 3.x 內,**不會自動跳 major**,所以唯一被降級的就是 spring minor。若要手動跳 major 並走 minor/major,用 `Release-As:` footer 或 `feat!:` 覆寫即可。

## 驗證

對照 release-please v17 真實原始碼做了三維度覆核(config 語意 / workflow YAML / 端到端雙閘門),皆通過:

- `changelog-sections` 完整取代預設,feat/fix 已明列保留發版
- 無殘留 `commit-type` 參照,`compare-version` 仍輸出 `comparison-result`
- `chore:` 標題通過 commitlint;App-token(Trap 15)完好
- 不會無限迴圈(commit 以 last-release SHA 為界)