### PR TITLE
ci: use CI App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,9 +25,15 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
       sha: ${{ steps.rp.outputs.sha }}
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5.0.0
         id: rp
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## What

Source release-please-action's token from the softleader CI App (actions/create-github-app-token@v3) instead of the default GITHUB_TOKEN.

## Why

GITHUB_TOKEN-produced events don't trigger other workflows (GitHub recursion guard), so a future on-release / on-push-tags listener wouldn't fire on a release-please release. The CI App is already wired in this repo (bump-spring.yml uses it). It also fixes the known autorelease label quirk and lets commitlint lint the release PR (the chore(main): release title is conventional-valid).

No recursion risk: the release PR is human-merged and release-please's own commits land on the release-please-- side branch, so it never self-triggers.

## Behavior changes

- release PR / Release actor reads as the App bot instead of github-actions[bot] (commit author/committer unchanged).
- release PR now gets a commitlint green check.