### PR TITLE
test(mapper): strengthen concurrency and nested-AND coverage

### DIFF
--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/NestedSpecificationResolverTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/NestedSpecificationResolverTest.java
@@ -111,7 +111,10 @@ class NestedSpecificationResolverTest {
             .extracting("specs", LIST)
             .hasSize(2);
     depth1.first().isInstanceOf(Equals.class);
-    depth1
+    var depth2 =
+        depth1.element(1).isInstanceOf(Conjunction.class).extracting("specs", LIST).hasSize(2);
+    depth2.first().isInstanceOf(Equals.class);
+    depth2
         .element(1)
         .isInstanceOf(Conjunction.class)
         .extracting("specs", LIST)
@@ -389,7 +392,7 @@ class NestedSpecificationResolverTest {
   @AllArgsConstructor
   public static class NestedInNestedAnd {
 
-    @NestedSpec String name;
+    @Spec String name;
   }
 
   @Builder

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/ReflectionDatabindTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/ReflectionDatabindTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -49,17 +50,28 @@ class ReflectionDatabindTest {
 
     assertThat(databind).hasSize(5);
 
-    var numberOfThreads = 1;
+    // Release every thread at the same instant so multiple threads race into
+    // getFieldValue() on the *same* Databind instances and genuinely contend on
+    // the AtomicBoolean CAS + CountDownLatch dedup.
+    var numberOfThreads = 32;
     var service = newFixedThreadPool(numberOfThreads);
-    var latch = new CountDownLatch(numberOfThreads);
+    var startBarrier = new CyclicBarrier(numberOfThreads);
+    var done = new CountDownLatch(numberOfThreads);
     for (int i = 0; i < numberOfThreads; i++) {
       service.submit(
           () -> {
-            databind.forEach(Databind::getFieldValue);
-            latch.countDown();
+            try {
+              startBarrier.await();
+              databind.forEach(Databind::getFieldValue);
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            } finally {
+              done.countDown();
+            }
           });
     }
-    latch.await();
+    done.await();
+    service.shutdown();
 
     databind.forEach(
         bind -> {


### PR DESCRIPTION
## Summary

Strengthens two mapper tests so they actually exercise the code paths they claim to cover (WP10, findings TEST-06 and TEST-05). Test-only change — no production code touched.

- **TEST-06 (concurrency).** `ReflectionDatabindTest.fireOnlyOnce` previously ran a single-threaded pool (`numberOfThreads = 1`), so the `AtomicBoolean` CAS + `CountDownLatch` dedup in `ReflectionDatabind.getFieldValue()` was never contended and the `times(1)` assertion would pass even if the dedup were deleted. It now launches 32 threads held at a `CyclicBarrier` and released together, so multiple threads race into `getFieldValue()` on the same `Databind` instances, while still asserting the inner reflective read runs exactly once per bind.
- **TEST-05 (three-level AND).** `NestedInNestedAnd.name` was annotated `@NestedSpec String name` (a typo vs its OR twin's `@Spec`), so recursing into a `String` yielded `null` and the deepest AND level was silently absent. Changed to `@Spec` (mirroring `NestedInNestedOr`) and extended `allAnd`'s assertions to a full three-level `Conjunction` tree symmetric to `allOr`'s `Disjunction` tree.

TEST-03 (inherited criteria fields) is deliberately out of scope — it needs a human policy decision and is tracked separately.

Closes #182

## Acceptance criteria

- [x] `ReflectionDatabindTest.fireOnlyOnce` launches 32 concurrent threads held at a start barrier and released together, so multiple threads call the same `ReflectionDatabind.getFieldValue()` concurrently.
- [x] For every `Databind` returned by `ReflectionDatabind.of(...)`, the test asserts the inner `getFieldValue(object, field)` read is invoked exactly once (`times(1)`) despite the concurrent access.
- [x] The strengthened concurrency test passes deterministically with no production-code change.
- [x] `NestedInNestedAnd.name` is annotated `@Spec` (matching `NestedInNestedOr.name`).
- [x] `allAnd` asserts a three-level `Conjunction` tree: top-level `Conjunction` of size 2 (`Equals` + nested `Conjunction`), nested `Conjunction` of size 2 (`Equals` + deepest `Conjunction`), deepest `Conjunction` of size 1 containing an `Equals`.
- [x] `allAnd`'s repository result still returns exactly `matt`.
- [x] `mvn test` (mapper module) passes.

## Testing

`mvn test` run on JDK 17 — full reactor green: `specification-mapper` and `specification-mapper-starter` both SUCCESS. The two affected classes: `ReflectionDatabindTest` (1 test) and `NestedSpecificationResolverTest` (5 tests) pass.
