### PR TITLE
fix(starter): harden auto-configuration and fluent findBySpec robustness

### DIFF
--- a/starter/src/main/java/tw/com/softleader/data/jpa/spec/starter/autoconfigure/SpecMapperAutoConfiguration.java
+++ b/starter/src/main/java/tw/com/softleader/data/jpa/spec/starter/autoconfigure/SpecMapperAutoConfiguration.java
@@ -27,19 +27,19 @@ import static org.springframework.util.Assert.notNull;
 import static tw.com.softleader.data.jpa.spec.ASTWriterFactory.impersonation;
 import static tw.com.softleader.data.jpa.spec.starter.autoconfigure.SpecMapperProperties.PREFIX_SPEC_MAPPER;
 
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
 import org.springframework.data.repository.core.support.RepositoryFactoryCustomizer;
@@ -57,7 +57,7 @@ import tw.com.softleader.data.jpa.spec.starter.repository.support.QueryBySpecExe
  */
 @Slf4j
 @RequiredArgsConstructor
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = JpaRepositoriesAutoConfiguration.class)
 @EnableConfigurationProperties(SpecMapperProperties.class)
 @ConditionalOnProperty(prefix = PREFIX_SPEC_MAPPER, value = "enabled", matchIfMissing = true)
 public class SpecMapperAutoConfiguration {
@@ -113,8 +113,8 @@ public class SpecMapperAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    JpaRepositoryFactoryBeanPostProcessor jpaRepositoryFactoryBeanPostProcessor(
-        List<RepositoryFactoryCustomizer> customizers) {
+    static JpaRepositoryFactoryBeanPostProcessor jpaRepositoryFactoryBeanPostProcessor(
+        ObjectProvider<RepositoryFactoryCustomizer> customizers) {
       return new JpaRepositoryFactoryBeanPostProcessor(customizers);
     }
 

--- a/starter/src/main/java/tw/com/softleader/data/jpa/spec/starter/repository/support/JpaRepositoryFactoryBeanPostProcessor.java
+++ b/starter/src/main/java/tw/com/softleader/data/jpa/spec/starter/repository/support/JpaRepositoryFactoryBeanPostProcessor.java
@@ -20,10 +20,10 @@
  */
 package tw.com.softleader.data.jpa.spec.starter.repository.support;
 
-import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
 import org.springframework.data.repository.core.support.RepositoryFactoryCustomizer;
@@ -37,13 +37,13 @@ import org.springframework.data.repository.core.support.RepositoryFactoryCustomi
 @RequiredArgsConstructor
 public class JpaRepositoryFactoryBeanPostProcessor implements BeanPostProcessor {
 
-  final List<RepositoryFactoryCustomizer> customizers;
+  final ObjectProvider<RepositoryFactoryCustomizer> customizers;
 
   @Override
   public Object postProcessBeforeInitialization(@NonNull Object bean, @NonNull String beanName)
       throws BeansException {
     if (bean instanceof JpaRepositoryFactoryBean<?, ?, ?> factoryBean) {
-      customizers.forEach(factoryBean::addRepositoryFactoryCustomizer);
+      customizers.orderedStream().forEach(factoryBean::addRepositoryFactoryCustomizer);
     }
     return bean;
   }

--- a/starter/src/main/java/tw/com/softleader/data/jpa/spec/starter/repository/support/QueryBySpecExecutorAdapter.java
+++ b/starter/src/main/java/tw/com/softleader/data/jpa/spec/starter/repository/support/QueryBySpecExecutorAdapter.java
@@ -113,7 +113,8 @@ public interface QueryBySpecExecutorAdapter<T>
     var domainClass = getDomainClass();
     notNull(mapper, "getSpecMapper() must not returns null");
     notNull(domainClass, "getDomainClass() must not returns null");
-    return findBy(mapper.toSpec(spec, domainClass), queryFunction);
+    var specification = mapper.toSpec(spec, domainClass);
+    return findBy(specification != null ? specification : (root, query, cb) -> null, queryFunction);
   }
 
   SpecMapper getSpecMapper();

--- a/starter/src/test/java/tw/com/softleader/data/jpa/spec/starter/repository/QueryBySpecExecutorTest.java
+++ b/starter/src/test/java/tw/com/softleader/data/jpa/spec/starter/repository/QueryBySpecExecutorTest.java
@@ -147,6 +147,17 @@ class QueryBySpecExecutorTest {
     assertThat(actual).hasSize(1).contains(matt);
   }
 
+  @Test
+  void findByEmptySpecAndQuery() {
+    var matt = repository.save(Customer.builder().name("matt").build());
+    var bob = repository.save(Customer.builder().name("bob").build());
+    var mary = repository.save(Customer.builder().name("mary").build());
+
+    var criteria = MyCriteria.builder().build();
+    var actual = repository.findBySpec(criteria, FluentQuery.FetchableFluentQuery::all);
+    assertThat(actual).hasSize(3).contains(matt, bob, mary);
+  }
+
   @Builder
   @Data
   static class MyCriteria {


### PR DESCRIPTION
## Summary

Hardens the starter's auto-configuration lifecycle and the fluent query API (WP6):

- **COR-13** — the fluent `findBySpec(Object, Function)` now tolerates empty/null criteria like every sibling `*BySpec` method, substituting an unrestricted specification when mapping yields `null` instead of letting Spring Data's `findBy` throw `IllegalArgumentException("Specification must not be null")`.
- **COR-12** — the `JpaRepositoryFactoryBeanPostProcessor` `@Bean` is now `static` and injects `ObjectProvider<RepositoryFactoryCustomizer>` (resolved lazily inside `postProcessBeforeInitialization`), so registering this `BeanPostProcessor` no longer force-instantiates customizer beans or the enclosing configuration class during the BPP registration phase.
- **MAINT-02** — `SpecMapperAutoConfiguration` is now `@AutoConfiguration(after = JpaRepositoriesAutoConfiguration.class)`, making the nested `@ConditionalOnBean(JpaRepositoryFactoryBean.class)` gate ordering contractual instead of dependent on alphabetical FQCN sorting.

MAINT-05 (API parity) is intentionally out of scope per the agent brief.

Closes #178

## Acceptance criteria

- [x] Fluent `findBySpec(Object, Function)` with empty criteria (all fields null) returns the fluent result over all rows rather than throwing; `null` criteria behaves identically to the other `*BySpec` methods.
- [x] New test `findByEmptySpecAndQuery` mirrors `findByEmptySpec` for the fluent variant (`FetchableFluentQuery::all` with empty criteria) and asserts all rows are returned.
- [x] The `@Bean` producing `JpaRepositoryFactoryBeanPostProcessor` no longer eagerly resolves a `List<RepositoryFactoryCustomizer>`; customizers are supplied lazily via `ObjectProvider` resolved inside `postProcessBeforeInitialization`, and the method is `static`.
- [x] `JpaRepositoryFactoryBeanPostProcessor` still applies every registered `RepositoryFactoryCustomizer` to each `JpaRepositoryFactoryBean` it post-processes (via `customizers.orderedStream()`).
- [x] `SpecMapperAutoConfiguration` is declared as a proper auto-configuration ordered after `JpaRepositoriesAutoConfiguration`.
- [x] The existing starter test suite continues to pass unchanged.

## Testing

`mvn test` across all modules — BUILD SUCCESS. `mapper` (96 tests) and `starter` (16 tests, including the new `findByEmptySpecAndQuery`) both green.

> [!WARNING]
> Higher-risk auto-configuration change. Please closely review the auto-config lifecycle/ordering: the `@AutoConfiguration(after = ...)` ordering, the `static` `@Bean` + lazy `ObjectProvider` resolution timing relative to `BeanPostProcessor` registration, and note that `SpecMapperAutoConfiguration` is shared with the deferred WP1/#173 — coordinate to avoid conflicts.
