### PR TITLE
fix(mapper): unwrap reflective spec construction exceptions in toSpec

### DIFF
--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/SimpleSpecification.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/SimpleSpecification.java
@@ -26,6 +26,7 @@ import static tw.com.softleader.data.jpa.spec.domain.JoinContext.CTX_JOIN;
 
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.StringJoiner;
 import lombok.Builder;
@@ -63,8 +64,22 @@ public abstract class SimpleSpecification<T> implements Specification<T> {
       @NonNull Class<? extends SimpleSpecification> domainClass,
       @NonNull String path,
       @NonNull Object value) {
-    return accessibleConstructor(domainClass, Context.class, String.class, Object.class)
-        .newInstance(context, path, value);
+    try {
+      return accessibleConstructor(domainClass, Context.class, String.class, Object.class)
+          .newInstance(context, path, value);
+    } catch (InvocationTargetException e) {
+      // Constructor.newInstance wraps any exception thrown inside the constructor in an
+      // InvocationTargetException; surface the original cause (e.g. TypeMismatchException,
+      // IllegalArgumentException) so it reaches SpecMapper.toSpec callers.
+      var cause = e.getCause();
+      if (cause instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      if (cause instanceof Error error) {
+        throw error;
+      }
+      throw new IllegalStateException(cause);
+    }
   }
 
   @SuppressWarnings({"unchecked"})

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/BetweenTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/BetweenTest.java
@@ -21,13 +21,19 @@
 package tw.com.softleader.data.jpa.spec.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.SpecMapper;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.usecase.Customer;
 import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
 
@@ -48,5 +54,23 @@ class BetweenTest {
             Arrays.asList(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1)));
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(1).contains(matt);
+  }
+
+  @Test
+  void oneElementThroughMapper() {
+    var mapper = SpecMapper.builder().build();
+    var birthday = List.of(LocalDate.now());
+    var criteria = BetweenCriteria.builder().birthday(birthday).build();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> mapper.toSpec(criteria, Customer.class))
+        .withMessage("@Between expected exact 2 elements, but was " + birthday);
+  }
+
+  @Builder
+  @Data
+  static class BetweenCriteria {
+
+    @Spec(value = Between.class)
+    List<LocalDate> birthday;
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/InTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/InTest.java
@@ -25,9 +25,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
 import java.util.Arrays;
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.SpecMapper;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.usecase.Customer;
 import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
 
@@ -55,5 +59,23 @@ class InTest {
         .isThrownBy(() -> new In<Customer>(context, "name", value))
         .withMessage(
             "Failed to convert value of type 'java.lang.Object' to required type 'java.lang.Iterable'");
+  }
+
+  @Test
+  void typeMismatchThroughMapper() {
+    var mapper = SpecMapper.builder().build();
+    var criteria = InCriteria.builder().name("matt").build();
+    assertThatExceptionOfType(TypeMismatchException.class)
+        .isThrownBy(() -> mapper.toSpec(criteria, Customer.class))
+        .withMessage(
+            "Failed to convert value of type 'java.lang.String' to required type 'java.lang.Iterable'");
+  }
+
+  @Builder
+  @Data
+  static class InCriteria {
+
+    @Spec(path = "name", value = In.class)
+    String name;
   }
 }


### PR DESCRIPTION
## Summary

`SimpleSpecification.newSpec` built specs via `Constructor.newInstance(...)` under `@SneakyThrows`. `Constructor.newInstance` wraps any exception thrown *inside* a spec constructor in a `java.lang.reflect.InvocationTargetException`, and `@SneakyThrows` rethrew that wrapper verbatim. As a result, the constructor-time validation exceptions — `TypeMismatchException` (from `In` / `Between` / boolean & comparable specs) and `IllegalArgumentException` (from `Between`) — were masked as `InvocationTargetException` at the `SpecMapper.toSpec` boundary. A downstream handler keyed on `TypeMismatchException` (e.g. to map it to an HTTP 400) never fired; callers got an opaque failure with the real message buried in the cause.

This change catches `InvocationTargetException` in `newSpec` and surfaces the original cause: `RuntimeException` / `Error` causes are rethrown unchanged (preserving their message), and checked causes are wrapped in `IllegalStateException` rather than leaked raw. `InvocationTargetException` can no longer escape `newSpec`.

Closes #177

## Acceptance criteria

- [x] `SpecMapper.toSpec` on a POJO whose `@Spec(In.class)` field holds a non-`Iterable` value throws `TypeMismatchException` (not `InvocationTargetException`) with the same message the direct constructor produces.
- [x] `SpecMapper.toSpec` on a POJO whose `@Spec(Between.class)` field is bound to a 1-element list throws `IllegalArgumentException` with the constructor's message (`@Between expected exact 2 elements...`).
- [x] `InvocationTargetException` never propagates out of `SimpleSpecification.newSpec`; a `RuntimeException` cause is rethrown unchanged, a checked cause is wrapped (`IllegalStateException`), not leaked raw.
- [x] New tests exercise the `SpecMapper.toSpec` path (constructing a query POJO and mapping it), not the direct spec constructor, for the In/non-Iterable and Between/1-element cases, asserting the surfaced exception type and message.
- [x] All existing direct-construction `typeMismatch` tests remain green.
- [x] `mvn test` passes.

Out of scope (per brief): MAINT-04 (`CTX_JOIN` hidden-invariant) is deferred pending a maintainer design decision; spec constructor exception *types* and any `starter/` HTTP-layer handling are unchanged.

## Testing

`mvn test` across all modules — BUILD SUCCESS. New coverage: `InTest.typeMismatchThroughMapper` (In on a `String` field → `TypeMismatchException`) and `BetweenTest.oneElementThroughMapper` (Between bound to a 1-element list → `IllegalArgumentException`), both driving the real `SpecMapper.toSpec` path.
