### PR TITLE
test(mapper): pin local-fields-only databind contract for inherited criteria fields

### DIFF
--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/ReflectionDatabind.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/ReflectionDatabind.java
@@ -69,6 +69,15 @@ class ReflectionDatabind implements Databind {
     return of(target, skippingStrategy, ReflectionDatabind::new, ReflectionDatabind::new);
   }
 
+  /**
+   * Builds the field lookup for {@code target}.
+   *
+   * <p><b>Local-fields-only contract:</b> this uses {@link ReflectionUtils#doWithLocalFields},
+   * which visits only fields declared directly on {@code target}'s concrete class. Fields inherited
+   * from a superclass (e.g. a shared base criteria POJO) are <em>not</em> included and therefore
+   * are never databound. Switching to {@link ReflectionUtils#doWithFields} to also include
+   * inherited fields would be a deliberate behavior change.
+   */
   // Visible for testing
   static List<Databind> of(
       @NonNull Object target,

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/ReflectionDatabindTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/ReflectionDatabindTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CyclicBarrier;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 
 class ReflectionDatabindTest {
 
@@ -81,6 +82,22 @@ class ReflectionDatabindTest {
         });
   }
 
+  @Test
+  void inheritedFieldsAreNotDatabound() {
+
+    // Pins the current doWithLocalFields contract: fields inherited from a superclass criteria
+    // POJO are silently excluded from the field lookup. If this ever needs to change (e.g. to
+    // support inherited criteria fields via doWithFields), this test must be updated
+    // deliberately.
+    var object = new ChildCriteria("childValue", "parentValue");
+
+    var databind = ReflectionDatabind.of(object, new DefaultSkippingStrategy());
+
+    assertThat(databind)
+        .extracting(bind -> bind.getField().getName())
+        .containsExactly("@type", "child");
+  }
+
   @AllArgsConstructor
   static class MyObject {
 
@@ -88,5 +105,20 @@ class ReflectionDatabindTest {
     Integer b;
     Optional<Long> c;
     Collection<String> d;
+  }
+
+  static class ParentCriteria {
+
+    @Spec String parent;
+  }
+
+  static class ChildCriteria extends ParentCriteria {
+
+    String child;
+
+    ChildCriteria(String child, String parent) {
+      this.child = child;
+      this.parent = parent;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #199

Pins the **current** `doWithLocalFields`-based, local-fields-only contract of `ReflectionDatabind.of()` with a test — this PR does **not** change any behavior.

- `ReflectionDatabind.of()` uses `ReflectionUtils.doWithLocalFields`, which only visits fields declared directly on the target's concrete class. Fields inherited from a superclass criteria POJO are silently excluded from databinding.
- Added `ReflectionDatabindTest#inheritedFieldsAreNotDatabound`, which builds a `ChildCriteria extends ParentCriteria` POJO (the parent carries an `@Spec`-annotated field) and asserts that the field lookup only contains the target-only entry and the child's own declared field — the inherited `parent` field is absent.
- Added a Javadoc note on the affected `ReflectionDatabind.of(...)` overload documenting the local-fields-only contract, so the limitation is discoverable at the source.

Whether inherited fields *should* be databound (e.g. switching to `doWithFields`) is a separate, deliberate maintainer decision — out of scope here.

## Test plan

- [x] `make test` — green (JDK 17 via SDKMAN; toolchain JDK on this machine resolves to 25 by default)
- [x] `mvn -pl mapper test -Dtest=ReflectionDatabindTest` — 2/2 passing, including the new pinning test
- [x] `npx --yes -p @commitlint/cli -p @commitlint/config-conventional commitlint --last --extends @commitlint/config-conventional` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)