### PR TITLE
ci: pin third-party actions to SHAs and gate PRs on an in-repo build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+# PR 建置門檻: 讓 auto-merge 的 PR (如 bump-spring 開的相依升版 PR) 在合併前
+# 有一個 in-repo 的建置/測試狀態可被 branch protection 要求, 不必只依賴 repo 外的 Jenkins。
+# 註: 完整的 java/spring 交叉測試仍由 Jenkinsfile 的 Matrix Tests 負責, 這裡只跑 pom.xml 當前組合。
+name: Build
+
+on:
+  pull_request:
+    branches: [jakarta]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - run: make test

--- a/.github/workflows/bump-snapshot.yml
+++ b/.github/workflows/bump-snapshot.yml
@@ -32,7 +32,7 @@ jobs:
       - id: get-current-version
         run: echo "current_version=$(make version)" >> "$GITHUB_OUTPUT"
       - id: bump
-        uses: "WyriHaximus/github-action-next-semvers@v1"
+        uses: WyriHaximus/github-action-next-semvers@d079934efaf011a4cf8912d4637097fe35d32b93 # v1
         with:
           version: ${{ steps.get-current-version.outputs.current_version }}
     outputs:
@@ -58,7 +58,7 @@ jobs:
             exit 1;
           fi
       - id: check-version
-        uses: mukunku/tag-exists-action@v1.7.0
+        uses: mukunku/tag-exists-action@5c39604fe8aef7e65acb6fbcf96ec580f7680313 # v1.7.0
         with:
           tag: '${{ steps.determine-version.outputs.final_version }}'
       - id: fail-if-version-exists
@@ -73,7 +73,7 @@ jobs:
     needs: ensure-version-not-exists
     steps:
       - id: specification-mapper-bump-snapshot
-        uses: shihyuho/go-jenkins-trigger@v2
+        uses: shihyuho/go-jenkins-trigger@d6f3216fa650324688da24cbf081472e29d35d57 # v2
         with:
           jenkins-url: "${{ secrets.JENKINS_URL }}"
           jenkins-user: "${{ secrets.JENKINS_USER }}"

--- a/.github/workflows/bump-spring.yml
+++ b/.github/workflows/bump-spring.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: get-latest-version
-        uses: shihyuho/go-spring-version@v1
+        uses: shihyuho/go-spring-version@9f72980d26ef9ec6b1b4858724135a4dc65e409a # v1
         with:
           boot-version: "~3.x"
     outputs:
@@ -39,7 +39,7 @@ jobs:
     needs: [latest-version, current-version]
     steps:
       - id: semver-compare
-        uses: madhead/semver-utils@latest
+        uses: madhead/semver-utils@4cf918affe9106ea59f86c6250e5ec4570ac4389 # v5.0.0
         with:
           version: ${{ needs.latest-version.outputs.spring-boot }}
           compare-to: ${{ needs.current-version.outputs.spring-boot }}
@@ -73,7 +73,7 @@ jobs:
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: bump spring-boot from ${{ needs.current-version.outputs.spring-boot }} to ${{ needs.latest-version.outputs.spring-boot }}"
@@ -98,4 +98,4 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v7
-      - uses: liskin/gh-workflow-keepalive@v1
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1.2.1

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
 
   # squash_merge_commit_title=COMMIT_OR_PR_TITLE -> 多 commit PR 的 squash subject = PR 標題,
   # 即 release-please 解析的 conventional commit。wagoid 只 lint commits 不 lint 標題,故額外補這個 job。

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           client-id: ${{ vars.CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-      - uses: googleapis/release-please-action@v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -43,7 +43,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     steps:
       - id: specification-mapper-release
-        uses: shihyuho/go-jenkins-trigger@v2
+        uses: shihyuho/go-jenkins-trigger@d6f3216fa650324688da24cbf081472e29d35d57 # v2
         with:
           jenkins-url: "${{ secrets.JENKINS_URL }}"
           jenkins-user: "${{ secrets.JENKINS_USER }}"

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: '0.157.0'
           extended: true
@@ -44,7 +44,7 @@ jobs:
       - run: hugo --baseURL https://${REPO_OWNER}.github.io/${REPO_NAME} --environment production --minify
         working-directory: site
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         if: ${{ github.ref == 'refs/heads/jakarta' }}
         with:
           github_token: ${{ github.token }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,10 @@ spec:
     }
     failure {
       script {
-        if (env.BRANCH_NAME == 'main'
+        // BRANCH_IS_PRIMARY 由 multibranch 的 branch-api 在 SCM 預設分支上設為 'true',
+        // 不必隨預設分支改名而改這裡; 非 multibranch job 不會有這個變數, 故 fallback 比對分支名
+        def isPrimaryBranch = env.BRANCH_IS_PRIMARY == 'true' || env.BRANCH_NAME == 'jakarta'
+        if (isPrimaryBranch
             // 若短時間太密集的 push, 之前的 job 會被 jenkins 中斷，這樣就可能會就連第一步都還沒執行的狀況，但也算是失敗
             // 然而取得 git 資訊就在第一步，所以至少要第一步都有執行完才發佈 slack 吧
             && env.LAST_COMMIT_AUTHOR_NAME && env.LAST_COMMIT_AUTHOR_EMAIL && env.LAST_COMMIT_TIME) {


### PR DESCRIPTION
Closes #197

WP12 — CI/CD supply-chain & gating. Addresses findings DEP-02, TEST-01, COR-02.

## DEP-02 — SHA-pin every third-party action

`bump-spring.yml` holds a repo-write App token and auto-merges the PRs it creates, so any third-party action it runs on a mutable tag was a supply-chain write path into the repo. All third-party actions across every workflow are now pinned to a full commit SHA with a version comment.

**Each SHA is the commit the previously referenced tag already resolved to**, so this pins current behaviour rather than upgrading anything.

| Workflow | Action | Old | New |
| --- | --- | --- | --- |
| `bump-spring.yml` | `madhead/semver-utils` | `@latest` | `@4cf918affe9106ea59f86c6250e5ec4570ac4389` # v5.0.0 |
| `bump-spring.yml` | `shihyuho/go-spring-version` | `@v1` | `@9f72980d26ef9ec6b1b4858724135a4dc65e409a` # v1 |
| `bump-spring.yml` | `peter-evans/create-pull-request` | `@v8` | `@5f6978faf089d4d20b00c7766989d076bb2fc7f1` # v8.1.1 |
| `bump-spring.yml` | `liskin/gh-workflow-keepalive` | `@v1` | `@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c` # v1.2.1 |
| `bump-snapshot.yml` | `WyriHaximus/github-action-next-semvers` | `@v1` | `@d079934efaf011a4cf8912d4637097fe35d32b93` # v1 |
| `bump-snapshot.yml` | `mukunku/tag-exists-action` | `@v1.7.0` | `@5c39604fe8aef7e65acb6fbcf96ec580f7680313` # v1.7.0 |
| `bump-snapshot.yml` | `shihyuho/go-jenkins-trigger` | `@v2` | `@d6f3216fa650324688da24cbf081472e29d35d57` # v2 |
| `release-please.yml` | `googleapis/release-please-action` | `@v5.0.0` | `@45996ed1f6d02564a971a2fa1b5860e934307cf7` # v5.0.0 |
| `release-please.yml` | `shihyuho/go-jenkins-trigger` | `@v2` | `@d6f3216fa650324688da24cbf081472e29d35d57` # v2 |
| `commitlint.yml` | `wagoid/commitlint-github-action` | `@v6` | `@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed` # v6.2.1 |
| `site-build.yml` | `peaceiris/actions-hugo` | `@v3` | `@2752ce1d29631191ea3f27c23495fa06139a5b78` # v3.2.1 |
| `site-build.yml` | `peaceiris/actions-gh-pages` | `@v4` | `@84c30a85c19949d7eee79c4ff27748b70285e453` # v4.1.0 |

First-party `actions/*` (`checkout@v7`, `setup-java@v5`, `setup-node@v6`, `github-script@v9`, `create-github-app-token@v3`) are deliberately left on major tags, matching existing repo convention and the issue's scope ("third-party").

> [!NOTE]
> `WyriHaximus/github-action-next-semvers@v1` is a **stale major alias** — it points at a 2020 commit (~v1.0.0), 63 commits behind `v1.2.1`. Pinning it preserves today's behaviour exactly; upgrading to `v1.2.1` would be a functional change, so it is left as a follow-up for the maintainer to decide.

## TEST-01 — in-repo PR build gate

New `.github/workflows/build.yml`: runs `make test` on `pull_request` targeting `jakarta` (plus `workflow_dispatch`), on JDK 17 / temurin with maven caching — matching the JDK setup and trigger style of the existing workflows. Declares `permissions: contents: read` and a cancel-in-progress concurrency group.

Auto-merged bump PRs now get an in-repo build/test status instead of depending entirely on out-of-repo Jenkins branch protection. The full java/spring cross-version matrix stays in `Jenkinsfile`; this gate only covers the combination `pom.xml` currently declares.

Uses `make test` rather than a raw `mvn verify` because every other CI entry point in this repo goes through the Makefile, and the Makefile is owned by a sibling work package in this batch.

> [!IMPORTANT]
> **Maintainer follow-up:** mark the new `Build / build` check **required** in branch protection for `jakarta`. That is a repository settings change and is outside the scope of this PR — until it is done, the gate reports status but does not block auto-merge.

## COR-02 — Jenkins failure notification guard

The failure notification was gated on `BRANCH_NAME == 'main'`, which is never true on the active `jakarta` line, so build failures notified nobody. It now keys on `BRANCH_IS_PRIMARY` — set to `'true'` by the multibranch branch-api plugin on the SCM default branch, so the guard survives a future default-branch rename — with a fallback to a literal `jakarta` name check for non-multibranch jobs where that variable is absent.

## Verification

- `make test` — **green** (15 tests, JDK 17 / temurin). Note: the build does *not* work on JDK 25; JDK 17 is required, which is what the new workflow pins.
- YAML parse of all 7 workflow files — OK.
- `actionlint` 1.7.12 — **no findings on `build.yml`** and none on any pinned line. The two pre-existing findings it reports (stale bundled metadata for `create-github-app-token`'s `client-id` input, and SC2086 in `site-build.yml`) are untouched by this PR.
- Every SHA was resolved via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` — none invented.

**Not verifiable locally:** the new workflow cannot be executed on this machine. Its first real run will be this PR itself, which is also the regression check the issue asks for.

## Scope

Touches only `.github/workflows/**` and `Jenkinsfile`. Does not touch `.github/dependabot.yml`, the pom files, or the Makefile — those belong to sibling work packages. No repository settings were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)