### PR TITLE
build: pin boot plugins, drop jar build-info, add maven dependabot lane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "maven"
+    directories:
+      - "/"
+      - "/mapper"
+      - "/starter"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Spring Boot has its own bump lane (.github/workflows/bump-spring.yml),
+      # which is pinned to the supported line. Leave it to that workflow.
+      - dependency-name: "org.springframework.boot:*"

--- a/mapper/pom.xml
+++ b/mapper/pom.xml
@@ -81,13 +81,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>build-info</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <jandex-maven-plugin.version>3.4.0</jandex-maven-plugin.version>
     <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+    <!-- Keep in sync with the native-build-tools-plugin.version managed by spring-boot-dependencies:${spring-boot.version} -->
+    <native-maven-plugin.version>0.10.6</native-maven-plugin.version>
 
     <spring-boot.version>3.5.16</spring-boot.version>
     <skip.formatting>false</skip.formatting>
@@ -185,6 +187,16 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>native-maven-plugin</artifactId>
+          <version>${native-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Closes #200

Delivers plan steps 1–3 of WP11. Step 4 (DEP-04) is deliberately out of scope — see below.

## What changed

### DEP-03 — plugins floating to Boot 4.x (`pom.xml`)

`spring-boot-maven-plugin` and `native-maven-plugin` were declared with no version, so Maven resolved them to the latest release regardless of the 3.5.16 BOM. Both are now pinned in the root `pluginManagement`.

`native-maven-plugin` is pinned to **0.10.6** rather than `${spring-boot.version}`: GraalVM's plugin does not share Boot's version scheme (there is no `native-maven-plugin:3.5.16`), so pinning it literally to `${spring-boot.version}` would break the `nativeTest` profile. 0.10.6 is exactly what `spring-boot-dependencies:3.5.16` manages as `native-build-tools-plugin.version`, so it tracks the Boot line as the plan intended. A comment on the new property records that coupling.

### COR-03 — jar shipped `build-info.properties` (`mapper/pom.xml`)

Removed the `build-info` execution. Nothing in the library reads it, and shipping it in a library jar hijacks a consumer's `BuildProperties` / `/actuator/info`. The bare plugin declaration is kept, matching `starter/pom.xml` and leaving the `nativeTest` profile's `process-test-aot` execution intact.

### DEP-01 — no Maven update lane (`.github/dependabot.yml`)

Added a `maven` ecosystem entry covering `/`, `/mapper`, and `/starter`.

Spring Boot is excluded via `ignore`. It already has a dedicated lane in `.github/workflows/bump-spring.yml` (capped at `~3.x`), and letting Dependabot also manage it would produce competing Boot 4.x PRs that pre-empt the DEP-04 decision below. Everything else — including the ~5-year-stale gpg plugin that the finding cites as evidence — now has an update lane.

`starter/pom.xml` needed no change; it inherits the pin.

## Verification

All builds run on **JDK 17** (the project's `maven.compiler.release`). The machine default is JDK 25, on which spotless/google-java-format fails to load — no POM versions were altered to work around it.

### 1. Plugins resolve to the Boot line, not 4.x

`mvn -pl mapper -PnativeTest help:effective-pom`

Before:
```
<artifactId>spring-boot-maven-plugin</artifactId>
<version>4.1.0</version>
<artifactId>native-maven-plugin</artifactId>
<version>1.1.5</version>
```

After:
```
<artifactId>spring-boot-maven-plugin</artifactId>
<version>3.5.16</version>
<artifactId>native-maven-plugin</artifactId>
<version>0.10.6</version>
```

`mvn -pl starter help:effective-pom` likewise reports `spring-boot-maven-plugin` at `3.5.16` (was `4.1.0`).

For reference, `spring-boot-dependencies-3.5.16.pom` line 151:
```
<native-build-tools-plugin.version>0.10.6</native-build-tools-plugin.version>
```

### 2. Jar no longer carries `META-INF/build-info.properties`

`mvn -q -pl mapper package -DskipTests && unzip -l mapper/target/*.jar | grep -i build-info`

Before — present:
```
178  07-20-2026 17:06   META-INF/build-info.properties
```

After — no matches (grep exit 1). Full `META-INF` listing confirms the jandex index and AOT factories survive:
```
META-INF/MANIFEST.MF
META-INF/spec-mapper/reflect-config.idx
META-INF/spring/aot.factories
META-INF/maven/tw.com.softleader.data.jakarta/specification-mapper/pom.xml
META-INF/maven/tw.com.softleader.data.jakarta/specification-mapper/pom.properties
```

### 3. `dependabot.yml` is valid YAML

Parsed with `yaml.safe_load`; ecosystems resolve to `['github-actions', 'maven']`.

### 4. `make test` green

```
[INFO] Reactor Summary for specification-mapper-parent 3.2.3-SNAPSHOT:
[INFO] specification-mapper-parent ........................ SUCCESS [  0.001 s]
[INFO] specification-mapper ............................... SUCCESS [ 10.229 s]
[INFO] specification-mapper-starter ....................... SUCCESS [  5.777 s]
[INFO] BUILD SUCCESS
```

## Not in this PR

**DEP-04 — Boot-line strategy is the maintainer's decision.** Whether to stay on a supported 3.x line or move to Boot 4, and the matching update to the `~3.x` cap in `bump-spring.yml`, is deferred. This PR does not change `spring-boot.version` (still 3.5.16) or that cap. Once the strategy is set it is a one-line follow-up — and the Dependabot `ignore` added here keeps that lane the workflow's alone in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
