### PR TITLE
fix(mapper): escape LIKE wildcards and chunk oversized IN clauses

### DIFF
--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/EndingWith.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/EndingWith.java
@@ -35,14 +35,16 @@ import org.springframework.lang.Nullable;
  * <p>In Criteria API, an equivalent expression might be:
  *
  * <pre>{@code
- * cb.like(root.get(path), "%" + value);
+ * cb.like(root.get(path), "%" + value, '\\');
  * }</pre>
  *
  * <p>This typically translates to SQL like:
  *
  * <pre>
- * {@code ... where x.firstname like %?}
+ * {@code ... where x.firstname like %? escape '\'}
  * </pre>
+ *
+ * <p>The value is matched literally, see {@link LikePattern}.
  *
  * @author Matt Ho
  * @see StartingWith
@@ -50,12 +52,12 @@ import org.springframework.lang.Nullable;
 public class EndingWith<T> extends SimpleSpecification<T> {
 
   public EndingWith(@NonNull Context context, @NonNull String path, @NonNull Object value) {
-    super(context, path, "%" + value);
+    super(context, path, "%" + LikePattern.escape(value));
   }
 
   @Override
   public Predicate toPredicate(
       @NonNull Root<T> root, @Nullable CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
-    return builder.like(getPath(root), Objects.toString(value));
+    return builder.like(getPath(root), Objects.toString(value), LikePattern.ESCAPE_CHAR);
   }
 }

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/In.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/In.java
@@ -26,6 +26,8 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.Arrays;
 import lombok.NonNull;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.lang.Nullable;
@@ -45,10 +47,21 @@ import org.springframework.lang.Nullable;
  * ... WHERE x.firstname IN (?, ?, ...)
  * }</pre>
  *
+ * <p>Collections larger than {@link #MAX_CHUNK_SIZE} are partitioned into OR-combined {@code IN}
+ * clauses.
+ *
  * @author Matt Ho
  * @see NotIn
  */
 public class In<T> extends SimpleSpecification<T> {
+
+  /**
+   * The maximum number of elements expanded into a single {@code IN} clause.
+   *
+   * <p>Several RDBMS cap the number of elements of an {@code IN} clause, commonly at 1000, and huge
+   * lists degrade the query plan; tune this to the target RDBMS if needed.
+   */
+  public static final int MAX_CHUNK_SIZE = 1000;
 
   public In(@NonNull Context context, @NonNull String path, @NonNull Object value) {
     super(context, path, value);
@@ -60,7 +73,16 @@ public class In<T> extends SimpleSpecification<T> {
   @Override
   public Predicate toPredicate(
       @NonNull Root<T> root, @Nullable CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
-    return getPath(root)
-        .in(stream(((Iterable<?>) value).spliterator(), false).toArray(Object[]::new));
+    var path = getPath(root);
+    var values = stream(((Iterable<?>) value).spliterator(), false).toArray(Object[]::new);
+    if (values.length <= MAX_CHUNK_SIZE) {
+      return path.in(values);
+    }
+    var chunks = new ArrayList<Predicate>();
+    for (var from = 0; from < values.length; from += MAX_CHUNK_SIZE) {
+      var to = Math.min(from + MAX_CHUNK_SIZE, values.length);
+      chunks.add(path.in(Arrays.copyOfRange(values, from, to)));
+    }
+    return builder.or(chunks.toArray(Predicate[]::new));
   }
 }

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Like.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Like.java
@@ -35,14 +35,16 @@ import org.springframework.lang.Nullable;
  * <p>In Criteria API, an equivalent expression might be:
  *
  * <pre>{@code
- * cb.like(root.get(path), "%" + value + "%");
+ * cb.like(root.get(path), "%" + value + "%", '\\');
  * }</pre>
  *
  * <p>This typically translates to SQL like:
  *
  * <pre>{@code
- * ... where x.firstname like %?%
+ * ... where x.firstname like %?% escape '\'
  * }</pre>
+ *
+ * <p>The value is matched literally, see {@link LikePattern}.
  *
  * @author Matt Ho
  * @see NotLike
@@ -50,12 +52,12 @@ import org.springframework.lang.Nullable;
 public class Like<T> extends SimpleSpecification<T> {
 
   public Like(@NonNull Context context, @NonNull String path, @NonNull Object value) {
-    super(context, path, "%" + value + "%");
+    super(context, path, "%" + LikePattern.escape(value) + "%");
   }
 
   @Override
   public Predicate toPredicate(
       @NonNull Root<T> root, @Nullable CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
-    return builder.like(getPath(root), Objects.toString(value));
+    return builder.like(getPath(root), Objects.toString(value), LikePattern.ESCAPE_CHAR);
   }
 }

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/LikePattern.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/LikePattern.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2022 SoftLeader
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package tw.com.softleader.data.jpa.spec.domain;
+
+import java.util.Objects;
+import lombok.NonNull;
+
+/**
+ * Composes the {@code LIKE} patterns used by {@link Like}, {@link NotLike}, {@link StartingWith}
+ * and {@link EndingWith}.
+ *
+ * <p>User supplied values are matched literally: the wildcards {@code %} and {@code _}, as well as
+ * the {@link #ESCAPE_CHAR escape character} itself, are escaped before being composed into a
+ * pattern.
+ *
+ * @author Matt Ho
+ */
+public final class LikePattern {
+
+  /** The escape character declared by every {@code LIKE} predicate of this package. */
+  public static final char ESCAPE_CHAR = '\\';
+
+  private LikePattern() {}
+
+  /**
+   * Escapes the {@code LIKE} wildcards of the given value, so that it is matched literally.
+   *
+   * @param value the value to escape
+   * @return the escaped value
+   */
+  public static String escape(@NonNull Object value) {
+    var text = Objects.toString(value);
+    var escaped = new StringBuilder(text.length());
+    for (var i = 0; i < text.length(); i++) {
+      var c = text.charAt(i);
+      if (c == ESCAPE_CHAR || c == '%' || c == '_') {
+        escaped.append(ESCAPE_CHAR);
+      }
+      escaped.append(c);
+    }
+    return escaped.toString();
+  }
+}

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/NotIn.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/NotIn.java
@@ -45,6 +45,9 @@ import org.springframework.lang.Nullable;
  * ... where x.firstname not in (?, ?, ...)
  * }</pre>
  *
+ * <p>Collections larger than {@link In#MAX_CHUNK_SIZE} are partitioned the same way {@link In}
+ * does, negating the OR-combined chunks as a whole.
+ *
  * @author Matt Ho
  * @see In
  */

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/NotLike.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/NotLike.java
@@ -36,14 +36,16 @@ import org.springframework.lang.Nullable;
  * <p>In Criteria API, an equivalent expression might be:
  *
  * <pre>{@code
- * cb.notLike(root.get(path), "%" + value + "%");
+ * cb.notLike(root.get(path), "%" + value + "%", '\\');
  * }</pre>
  *
  * <p>This typically translates to SQL like:
  *
  * <pre>{@code
- * ... where x.firstname not like %?%
+ * ... where x.firstname not like %?% escape '\'
  * }</pre>
+ *
+ * <p>The value is matched literally, see {@link LikePattern}.
  *
  * @author Matt Ho
  * @see Like
@@ -51,12 +53,12 @@ import org.springframework.lang.Nullable;
 public class NotLike<T> extends SimpleSpecification<T> {
 
   public NotLike(@NonNull Context context, @NonNull String path, @NonNull Object value) {
-    super(context, path, "%" + value + "%");
+    super(context, path, "%" + LikePattern.escape(value) + "%");
   }
 
   @Override
   public Predicate toPredicate(
       @NonNull Root<T> root, @Nullable CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
-    return builder.notLike(getPath(root), Objects.toString(value));
+    return builder.notLike(getPath(root), Objects.toString(value), LikePattern.ESCAPE_CHAR);
   }
 }

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/StartingWith.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/StartingWith.java
@@ -35,14 +35,16 @@ import org.springframework.lang.Nullable;
  * <p>In Criteria API, an equivalent expression might be:
  *
  * <pre>{@code
- * cb.like(root.get(path), value + "%");
+ * cb.like(root.get(path), value + "%", '\\');
  * }</pre>
  *
  * <p>This typically translates to SQL like:
  *
  * <pre>
- * {@code ... where x.firstname like ?%}
+ * {@code ... where x.firstname like ?% escape '\'}
  * </pre>
+ *
+ * <p>The value is matched literally, see {@link LikePattern}.
  *
  * @author Matt Ho
  * @see EndingWith
@@ -50,12 +52,12 @@ import org.springframework.lang.Nullable;
 public class StartingWith<T> extends SimpleSpecification<T> {
 
   public StartingWith(@NonNull Context context, @NonNull String path, @NonNull Object value) {
-    super(context, path, value + "%");
+    super(context, path, LikePattern.escape(value) + "%");
   }
 
   @Override
   public Predicate toPredicate(
       @NonNull Root<T> root, @Nullable CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
-    return builder.like(getPath(root), Objects.toString(value));
+    return builder.like(getPath(root), Objects.toString(value), LikePattern.ESCAPE_CHAR);
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/DomainRuntimeHintsTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/DomainRuntimeHintsTest.java
@@ -58,6 +58,7 @@ class DomainRuntimeHintsTest {
     assertThat(reflection().onType(LessThan.class)).accepts(hints);
     assertThat(reflection().onType(LessThanEqual.class)).accepts(hints);
     assertThat(reflection().onType(Like.class)).accepts(hints);
+    assertThat(reflection().onType(LikePattern.class)).accepts(hints);
     assertThat(reflection().onType(Not.class)).accepts(hints);
     assertThat(reflection().onType(NotEquals.class)).accepts(hints);
     assertThat(reflection().onType(NotIn.class)).accepts(hints);

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/EndingWithTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/EndingWithTest.java
@@ -23,9 +23,13 @@ package tw.com.softleader.data.jpa.spec.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.SpecMapper;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.usecase.Customer;
 import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
 
@@ -42,5 +46,25 @@ class EndingWithTest {
     var spec = new EndingWith<Customer>(noopContext(), "name", "tt");
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(1).contains(matt);
+  }
+
+  @Test
+  void wildcardsMatchLiterally() {
+    var wildcard = repository.save(Customer.builder().name("bypass_").build());
+    repository.save(Customer.builder().name("matt").build());
+    repository.save(Customer.builder().name("bob").build());
+
+    var mapper = SpecMapper.builder().build();
+    var spec = mapper.toSpec(EndingWithCriteria.builder().name("_").build(), Customer.class);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(1).contains(wildcard);
+  }
+
+  @Builder
+  @Data
+  static class EndingWithCriteria {
+
+    @Spec(path = "name", value = EndingWith.class)
+    String name;
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/InTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/InTest.java
@@ -24,7 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.stream.IntStream;
 import lombok.Builder;
 import lombok.Data;
 import org.junit.jupiter.api.Test;
@@ -49,6 +51,20 @@ class InTest {
     var spec = new In<Customer>(noopContext(), "name", Arrays.asList("matt", "bob"));
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(2).contains(matt, bob);
+  }
+
+  @Test
+  void moreValuesThanChunkSize() {
+    var matt = repository.save(Customer.builder().name("matt").build());
+    repository.save(Customer.builder().name("bob").build());
+
+    var values = new ArrayList<String>();
+    IntStream.rangeClosed(1, In.MAX_CHUNK_SIZE).mapToObj(i -> "name-" + i).forEach(values::add);
+    values.add("matt");
+
+    var spec = new In<Customer>(noopContext(), "name", values);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(1).contains(matt);
   }
 
   @Test

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/LikeTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/LikeTest.java
@@ -23,9 +23,14 @@ package tw.com.softleader.data.jpa.spec.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.SpecMapper;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.usecase.Customer;
 import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
 
@@ -43,5 +48,30 @@ class LikeTest {
     var spec = new Like<Customer>(context, "name", "at");
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(1).contains(matt);
+  }
+
+  @Test
+  void wildcardsMatchLiterally() {
+    var percent = repository.save(Customer.builder().name("a%b").build());
+    var underscore = repository.save(Customer.builder().name("a_b").build());
+    var backslash = repository.save(Customer.builder().name("a\\b").build());
+    repository.save(Customer.builder().name("axb").build());
+
+    var mapper = SpecMapper.builder().build();
+    assertThat(repository.findAll(toSpec(mapper, "a%b"))).hasSize(1).contains(percent);
+    assertThat(repository.findAll(toSpec(mapper, "a_b"))).hasSize(1).contains(underscore);
+    assertThat(repository.findAll(toSpec(mapper, "a\\b"))).hasSize(1).contains(backslash);
+  }
+
+  private Specification<Customer> toSpec(SpecMapper mapper, String name) {
+    return mapper.toSpec(LikeCriteria.builder().name(name).build(), Customer.class);
+  }
+
+  @Builder
+  @Data
+  static class LikeCriteria {
+
+    @Spec(path = "name", value = Like.class)
+    String name;
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/NotInTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/NotInTest.java
@@ -24,7 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
@@ -45,6 +47,20 @@ class NotInTest {
     var spec = new NotIn<Customer>(noopContext(), "name", Arrays.asList("matt", "bob"));
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(1).contains(mary);
+  }
+
+  @Test
+  void moreValuesThanChunkSize() {
+    repository.save(Customer.builder().name("matt").build());
+    var bob = repository.save(Customer.builder().name("bob").build());
+
+    var values = new ArrayList<String>();
+    IntStream.rangeClosed(1, In.MAX_CHUNK_SIZE).mapToObj(i -> "name-" + i).forEach(values::add);
+    values.add("matt");
+
+    var spec = new NotIn<Customer>(noopContext(), "name", values);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(1).contains(bob);
   }
 
   @Test

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/NotLikeTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/NotLikeTest.java
@@ -23,9 +23,13 @@ package tw.com.softleader.data.jpa.spec.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.SpecMapper;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.usecase.Customer;
 import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
 
@@ -43,5 +47,26 @@ class NotLikeTest {
     var spec = new NotLike<Customer>(context, "name", "o");
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(1).contains(matt);
+  }
+
+  @Test
+  void wildcardsMatchLiterally() {
+    repository.save(Customer.builder().name("a%b").build());
+    var underscore = repository.save(Customer.builder().name("a_b").build());
+    var backslash = repository.save(Customer.builder().name("a\\b").build());
+    var plain = repository.save(Customer.builder().name("axb").build());
+
+    var mapper = SpecMapper.builder().build();
+    var spec = mapper.toSpec(NotLikeCriteria.builder().name("a%b").build(), Customer.class);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(3).contains(underscore, backslash, plain);
+  }
+
+  @Builder
+  @Data
+  static class NotLikeCriteria {
+
+    @Spec(path = "name", value = NotLike.class)
+    String name;
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/StartingWithTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/StartingWithTest.java
@@ -23,9 +23,13 @@ package tw.com.softleader.data.jpa.spec.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
+import lombok.Builder;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.SpecMapper;
+import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.usecase.Customer;
 import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
 
@@ -42,5 +46,26 @@ class StartingWithTest {
     var spec = new StartingWith<Customer>(noopContext(), "name", "ma");
     var actual = repository.findAll(spec);
     assertThat(actual).hasSize(1).contains(matt);
+  }
+
+  /** A bare {@code %} must not bypass the prefix scoping by matching every row. */
+  @Test
+  void wildcardsMatchLiterally() {
+    var wildcard = repository.save(Customer.builder().name("%bypass").build());
+    repository.save(Customer.builder().name("matt").build());
+    repository.save(Customer.builder().name("bob").build());
+
+    var mapper = SpecMapper.builder().build();
+    var spec = mapper.toSpec(StartingWithCriteria.builder().name("%").build(), Customer.class);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(1).contains(wildcard);
+  }
+
+  @Builder
+  @Data
+  static class StartingWithCriteria {
+
+    @Spec(path = "name", value = StartingWith.class)
+    String name;
   }
 }


### PR DESCRIPTION
Closes #194

## What changed

### SEC-01 — LIKE-family wildcard leakage

`Like`, `NotLike`, `StartingWith` and `EndingWith` concatenated the user value straight into the
`LIKE` pattern, so a submitted `%` or `_` kept its wildcard meaning. A bare `%` through a
`StartingWith`-mapped scoping filter (e.g. a tenant/department prefix) produced `like '%%'` and
matched every row — a scoping bypass. Values are bound parameters, so this is wildcard-semantics
leakage, not SQL injection.

- New `LikePattern` helper in the `domain` package: escapes `\`, `%` and `_` in a single pass (the
  escape character itself is handled first by construction, so no double-escaping), and exposes
  `LikePattern.ESCAPE_CHAR` (`\`).
- All four specs now escape the value before composing the pattern and use the escape-aware
  overloads `builder.like(expr, pattern, '\\')` / `builder.notLike(expr, pattern, '\\')`.
- Javadoc on each spec updated to state the literal-match guarantee.

### MAINT-03 — unbounded `IN` expansion

`In` expanded the entire user collection into one `IN (...)` list; several RDBMS cap the element
count (commonly 1000) and huge lists degrade the query plan.

- `In.MAX_CHUNK_SIZE = 1000` (documented, maintainer-tunable per target RDBMS).
- Collections larger than the chunk size are partitioned into OR-combined `IN` predicates.
  Collections at or below it take the previous single-predicate path, so the common case and the
  empty-collection case are unchanged.
- `NotIn` inherits this and negates the OR-combined chunks as a whole, which is the correct
  De Morgan equivalent of `NOT IN (all)`.

## Release note (behavior change)

**Consumers who deliberately passed raw `%` or `_` through LIKE-family fields lose that
(undocumented) behavior.** From this release, values bound to `Like`, `NotLike`, `StartingWith` and
`EndingWith` are matched **literally** — wildcards in the value are escaped. Callers that relied on
user- or code-supplied wildcards reaching the database must now build the pattern with their own
specification.

## Verification

- New tests, each asserting through `SpecMapper.toSpec`:
  - `LikeTest.wildcardsMatchLiterally` — values containing `%`, `_` and `\` each match only their
    literal row.
  - `StartingWithTest.wildcardsMatchLiterally` — the reported prefix-scope bypass: a bare `%` now
    matches only the row that literally starts with `%`, not every row.
  - `EndingWithTest.wildcardsMatchLiterally`, `NotLikeTest.wildcardsMatchLiterally`.
  - `InTest.moreValuesThanChunkSize` / `NotInTest.moreValuesThanChunkSize` — 1001 values (2 chunks)
    build valid SQL and return the correct rows.
- Negative check: with the four LIKE-family source files reverted and the new tests kept, all four
  `wildcardsMatchLiterally` tests fail — they genuinely pin the fix.
- `make test` green on both modules (JDK 17, the project's declared target).

## Not done

- No changes outside `mapper/src/main/.../domain/` and `mapper/src/test/` — the site docs under
  `site/content/**` that describe the LIKE-family specs are left to the maintainer / release notes.
- No case-insensitive (`IgnoreCase`) siblings exist in this family, so nothing further to escape.
- Chunk size is a source constant, not runtime configuration — the issue asks for a documented
  default the maintainer may tune, not a new config surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
