### PR TITLE
fix(mapper): honor first-position @Or/@And in compound composition

### DIFF
--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/SimpleSpecificationResolver.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/SimpleSpecificationResolver.java
@@ -85,10 +85,19 @@ class SimpleSpecificationResolver implements SpecificationResolver {
     if (def.not()) {
       spec = new Not<>(spec);
     }
-    if (databind.getField().isAnnotationPresent(And.class)) {
+    var and = databind.getField().isAnnotationPresent(And.class);
+    var or = databind.getField().isAnnotationPresent(Or.class);
+    if (and && or) {
+      throw new IllegalArgumentException(
+          "@And and @Or are mutually exclusive, but both are present on "
+              + databind.getTarget().getClass().getName()
+              + "."
+              + databind.getField().getName());
+    }
+    if (and) {
       return new tw.com.softleader.data.jpa.spec.domain.And<>(spec);
     }
-    if (databind.getField().isAnnotationPresent(Or.class)) {
+    if (or) {
       return new tw.com.softleader.data.jpa.spec.domain.Or<>(spec);
     }
     return spec;

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/CompoundSpecification.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/CompoundSpecification.java
@@ -20,11 +20,13 @@
  */
 package tw.com.softleader.data.jpa.spec.domain;
 
+import static java.util.Comparator.comparing;
+
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-import java.util.Collection;
+import java.util.List;
 import java.util.StringJoiner;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -36,16 +38,27 @@ import org.springframework.data.jpa.domain.Specification;
 @RequiredArgsConstructor
 abstract class CompoundSpecification<T> implements Specification<T> {
 
-  @NonNull protected final transient Collection<Specification<T>> specs;
+  @NonNull protected final transient List<Specification<T>> specs;
 
+  /**
+   * Fold 的結果會相依於 element 的順序, 因此在 Fold 前會先把所有覆寫了預設運算子的 element 穩定排序到最後, 如此一來第一個 element
+   * 就必定是使用預設運算子的, 也就不會有 Wrapper 被忽略的問題; 換句話說, 無論欄位的宣告順序為何, 都會得到相同的組合結果
+   */
   @Override
   public Predicate toPredicate(
       @NonNull Root<T> root, CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
     return specs.stream()
+        .sorted(comparing(this::overridesOperator))
         .reduce(this::combine)
         .map(spec -> spec.toPredicate(root, query, builder))
         .orElse(null);
   }
+
+  /**
+   * @param element 要檢查的元素
+   * @return 該元素是否覆寫了本 Compound 的預設運算子
+   */
+  protected abstract boolean overridesOperator(Specification<T> element);
 
   /**
    * @param result 到目前 Combine 的結果

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Conjunction.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Conjunction.java
@@ -20,7 +20,7 @@
  */
 package tw.com.softleader.data.jpa.spec.domain;
 
-import java.util.Collection;
+import java.util.List;
 import lombok.NonNull;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -29,13 +29,18 @@ import org.springframework.data.jpa.domain.Specification;
  */
 public class Conjunction<T> extends CompoundSpecification<T> {
 
-  public Conjunction(@NonNull Collection<Specification<T>> specs) {
+  public Conjunction(@NonNull List<Specification<T>> specs) {
     super(specs);
   }
 
   @Override
+  protected boolean overridesOperator(Specification<T> element) {
+    return element instanceof Or;
+  }
+
+  @Override
   protected Specification<T> combine(Specification<T> result, Specification<T> element) {
-    if (element instanceof Or) {
+    if (overridesOperator(element)) {
       return result.or(element);
     }
     return result.and(element);

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Disjunction.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Disjunction.java
@@ -20,7 +20,7 @@
  */
 package tw.com.softleader.data.jpa.spec.domain;
 
-import java.util.Collection;
+import java.util.List;
 import lombok.NonNull;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -29,13 +29,18 @@ import org.springframework.data.jpa.domain.Specification;
  */
 public class Disjunction<T> extends CompoundSpecification<T> {
 
-  public Disjunction(@NonNull Collection<Specification<T>> specs) {
+  public Disjunction(@NonNull List<Specification<T>> specs) {
     super(specs);
   }
 
   @Override
+  protected boolean overridesOperator(Specification<T> element) {
+    return element instanceof And;
+  }
+
+  @Override
   protected Specification<T> combine(Specification<T> result, Specification<T> element) {
-    if (element instanceof And) {
+    if (overridesOperator(element)) {
       return result.and(element);
     }
     return result.or(element);

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/SimpleSpecificationResolverTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/SimpleSpecificationResolverTest.java
@@ -21,6 +21,7 @@
 package tw.com.softleader.data.jpa.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -248,12 +249,13 @@ class SimpleSpecificationResolverTest {
                 .gender(Gender.MALE)
                 .birthday(LocalDate.now().plusDays(1))
                 .build());
-    repository.save(
-        Customer.builder()
-            .name("mary")
-            .gender(Gender.FEMALE)
-            .birthday(LocalDate.now().minusDays(1))
-            .build());
+    var mary =
+        repository.save(
+            Customer.builder()
+                .name("mary")
+                .gender(Gender.FEMALE)
+                .birthday(LocalDate.now().minusDays(1))
+                .build());
 
     var criteria =
         ForceOr2.builder()
@@ -278,10 +280,99 @@ class SimpleSpecificationResolverTest {
         .isInstanceOf(After.class);
     depth1.element(2).isInstanceOf(Equals.class);
     var actual = repository.findAll(spec);
-    assertThat(actual).hasSize(2).contains(matt, bob);
+    assertThat(actual).hasSize(3).contains(matt, bob, mary);
 
     verify(simpleResolver, times(numberOfLocalField(ForceOr2.class)))
         .buildSpecification(any(Context.class), any(Databind.class));
+  }
+
+  @DisplayName("Force Or 3 - @Or 宣告在第一順位")
+  @Test
+  void forceOr3() {
+    var matt =
+        repository.save(
+            Customer.builder().name("matt").gender(Gender.MALE).birthday(LocalDate.now()).build());
+    var bob =
+        repository.save(
+            Customer.builder()
+                .name("bob")
+                .gender(Gender.MALE)
+                .birthday(LocalDate.now().plusDays(1))
+                .build());
+    var mary =
+        repository.save(
+            Customer.builder()
+                .name("mary")
+                .gender(Gender.FEMALE)
+                .birthday(LocalDate.now().minusDays(1))
+                .build());
+
+    var criteria =
+        ForceOr3.builder()
+            .name(bob.getName())
+            .gender(bob.getGender())
+            .birthday(LocalDate.now())
+            .build();
+    var spec = mapper.toSpec(criteria, Customer.class);
+    var depth1 =
+        assertThat(spec)
+            .isNotNull()
+            .isInstanceOf(Conjunction.class)
+            .extracting("specs", LIST)
+            .hasSize(3);
+    depth1
+        .first()
+        .isInstanceOf(tw.com.softleader.data.jpa.spec.domain.Or.class)
+        .extracting("spec")
+        .isInstanceOf(Not.class)
+        .extracting("spec")
+        .isInstanceOf(After.class);
+    depth1.element(1).isInstanceOf(Equals.class);
+    depth1.element(2).isInstanceOf(Equals.class);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(3).contains(matt, bob, mary);
+
+    verify(simpleResolver, times(numberOfLocalField(ForceOr3.class)))
+        .buildSpecification(any(Context.class), any(Databind.class));
+  }
+
+  @DisplayName("@Or 無論宣告在哪個順位都得到相同的結果")
+  @Test
+  void forceOrIsPermutationInvariant() {
+    repository.save(
+        Customer.builder().name("matt").gender(Gender.MALE).birthday(LocalDate.now()).build());
+    repository.save(
+        Customer.builder()
+            .name("bob")
+            .gender(Gender.MALE)
+            .birthday(LocalDate.now().plusDays(1))
+            .build());
+    repository.save(
+        Customer.builder()
+            .name("mary")
+            .gender(Gender.FEMALE)
+            .birthday(LocalDate.now().minusDays(1))
+            .build());
+
+    var birthday = LocalDate.now();
+    var expected =
+        repository.findAll(
+            mapper.toSpec(
+                ForceOr.builder().name("bob").gender(Gender.MALE).birthday(birthday).build(),
+                Customer.class));
+    assertThat(expected).isNotEmpty();
+    assertThat(
+            repository.findAll(
+                mapper.toSpec(
+                    ForceOr2.builder().name("bob").gender(Gender.MALE).birthday(birthday).build(),
+                    Customer.class)))
+        .containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(
+            repository.findAll(
+                mapper.toSpec(
+                    ForceOr3.builder().name("bob").gender(Gender.MALE).birthday(birthday).build(),
+                    Customer.class)))
+        .containsExactlyInAnyOrderElementsOf(expected);
   }
 
   @DisplayName("Force And")
@@ -331,6 +422,112 @@ class SimpleSpecificationResolverTest {
 
     verify(simpleResolver, times(numberOfLocalField(ForceAnd.class)))
         .buildSpecification(any(Context.class), any(Databind.class));
+  }
+
+  @DisplayName("Force And 2 - @And 宣告在第一順位")
+  @Test
+  void forceAnd2() {
+    var matt =
+        repository.save(
+            Customer.builder().name("matt").gender(Gender.MALE).birthday(LocalDate.now()).build());
+    repository.save(
+        Customer.builder()
+            .name("bob")
+            .gender(Gender.MALE)
+            .birthday(LocalDate.now().plusDays(1))
+            .build());
+    var mary =
+        repository.save(
+            Customer.builder()
+                .name("mary")
+                .gender(Gender.FEMALE)
+                .birthday(LocalDate.now().minusDays(1))
+                .build());
+
+    var criteria =
+        ForceAnd2.builder()
+            .name(matt.getName())
+            .gender(mary.getGender())
+            .birthday(LocalDate.now())
+            .build();
+    var spec = mapper.toSpec(criteria, Customer.class);
+    var depth1 =
+        assertThat(spec)
+            .isNotNull()
+            .isInstanceOf(Disjunction.class)
+            .extracting("specs", LIST)
+            .hasSize(3);
+    depth1
+        .first()
+        .isInstanceOf(tw.com.softleader.data.jpa.spec.domain.And.class)
+        .extracting("spec")
+        .isInstanceOf(Not.class)
+        .extracting("spec")
+        .isInstanceOf(After.class);
+    depth1.element(1).isInstanceOf(Equals.class);
+    depth1.element(2).isInstanceOf(Equals.class);
+    var actual = repository.findAll(spec);
+    assertThat(actual).hasSize(2).contains(matt, mary);
+
+    verify(simpleResolver, times(numberOfLocalField(ForceAnd2.class)))
+        .buildSpecification(any(Context.class), any(Databind.class));
+  }
+
+  @DisplayName("@And 無論宣告在哪個順位都得到相同的結果")
+  @Test
+  void forceAndIsPermutationInvariant() {
+    repository.save(
+        Customer.builder().name("matt").gender(Gender.MALE).birthday(LocalDate.now()).build());
+    repository.save(
+        Customer.builder()
+            .name("bob")
+            .gender(Gender.MALE)
+            .birthday(LocalDate.now().plusDays(1))
+            .build());
+    repository.save(
+        Customer.builder()
+            .name("mary")
+            .gender(Gender.FEMALE)
+            .birthday(LocalDate.now().minusDays(1))
+            .build());
+
+    var birthday = LocalDate.now();
+    var expected =
+        repository.findAll(
+            mapper.toSpec(
+                ForceAnd.builder().name("matt").gender(Gender.FEMALE).birthday(birthday).build(),
+                Customer.class));
+    assertThat(expected).isNotEmpty();
+    assertThat(
+            repository.findAll(
+                mapper.toSpec(
+                    ForceAnd2.builder()
+                        .name("matt")
+                        .gender(Gender.FEMALE)
+                        .birthday(birthday)
+                        .build(),
+                    Customer.class)))
+        .containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(
+            repository.findAll(
+                mapper.toSpec(
+                    ForceAnd3.builder()
+                        .name("matt")
+                        .gender(Gender.FEMALE)
+                        .birthday(birthday)
+                        .build(),
+                    Customer.class)))
+        .containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @DisplayName("同一個欄位同時標註 @And 及 @Or 時拋出例外")
+  @Test
+  void andOrAreMutuallyExclusive() {
+    var criteria = AndOrConflict.builder().name("matt").build();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> mapper.toSpec(criteria, Customer.class))
+        .withMessageContaining("@And and @Or are mutually exclusive")
+        .withMessageContaining(AndOrConflict.class.getName() + ".name");
   }
 
   int numberOfLocalField(@NonNull Class<?> clazz) {
@@ -446,6 +643,19 @@ class SimpleSpecificationResolverTest {
     @Spec Gender gender;
   }
 
+  @Builder
+  @Data
+  public static class ForceOr3 {
+
+    @Or
+    @Spec(value = After.class, not = true)
+    LocalDate birthday;
+
+    @Spec String name;
+
+    @Spec Gender gender;
+  }
+
   @Or
   @Builder
   @Data
@@ -458,6 +668,41 @@ class SimpleSpecificationResolverTest {
     @And
     @Spec(value = After.class, not = true)
     LocalDate birthday;
+  }
+
+  @Or
+  @Builder
+  @Data
+  public static class ForceAnd2 {
+
+    @And
+    @Spec(value = After.class, not = true)
+    LocalDate birthday;
+
+    @Spec String name;
+
+    @Spec Gender gender;
+  }
+
+  @Or
+  @Builder
+  @Data
+  public static class ForceAnd3 {
+
+    @Spec String name;
+
+    @And
+    @Spec(value = After.class, not = true)
+    LocalDate birthday;
+
+    @Spec Gender gender;
+  }
+
+  @Builder
+  @Data
+  public static class AndOrConflict {
+
+    @And @Or @Spec String name;
   }
 
   @Builder

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/ConjunctionTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/ConjunctionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2022 SoftLeader
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package tw.com.softleader.data.jpa.spec.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.usecase.Customer;
+import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
+import tw.com.softleader.data.jpa.spec.usecase.Gender;
+
+@IntegrationTest
+class ConjunctionTest {
+
+  @Autowired CustomerRepository repository;
+
+  Customer matt;
+  Customer bob;
+  Customer mary;
+
+  Specification<Customer> nameIsBob;
+  Specification<Customer> genderIsFemale;
+  Specification<Customer> nameIsMary;
+
+  @BeforeEach
+  void setup() {
+    matt = repository.save(Customer.builder().name("matt").gender(Gender.MALE).build());
+    bob = repository.save(Customer.builder().name("bob").gender(Gender.MALE).build());
+    mary = repository.save(Customer.builder().name("mary").gender(Gender.FEMALE).build());
+
+    nameIsBob = new Equals<>(noopContext(), "name", "bob");
+    genderIsFemale = new Equals<>(noopContext(), "gender", Gender.FEMALE);
+    nameIsMary = new Equals<>(noopContext(), "name", "mary");
+  }
+
+  @DisplayName("combine 沒有 Wrapper 的元素時使用 And")
+  @Test
+  void combineWithoutWrapper() {
+    var conjunction = new Conjunction<Customer>(List.of());
+    var combined = conjunction.combine(genderIsFemale, nameIsBob);
+    assertThat(repository.findAll(combined)).isEmpty();
+  }
+
+  @DisplayName("combine 有 Or Wrapper 的元素時使用 Or")
+  @Test
+  void combineWithOrWrapper() {
+    var conjunction = new Conjunction<Customer>(List.of());
+    var combined = conjunction.combine(genderIsFemale, new Or<>(nameIsBob));
+    assertThat(repository.findAll(combined)).containsExactlyInAnyOrder(bob, mary);
+  }
+
+  @DisplayName("overridesOperator 只認得 Or")
+  @Test
+  void overridesOperator() {
+    var conjunction = new Conjunction<Customer>(List.of());
+    assertThat(conjunction.overridesOperator(new Or<>(nameIsBob))).isTrue();
+    assertThat(conjunction.overridesOperator(new And<>(nameIsBob))).isFalse();
+    assertThat(conjunction.overridesOperator(nameIsBob)).isFalse();
+  }
+
+  @DisplayName("第一順位的 Or 不會被忽略")
+  @Test
+  void orOnFirstPositionIsNotIgnored() {
+    var spec = new Conjunction<>(List.of(new Or<>(nameIsBob), genderIsFemale));
+    assertThat(repository.findAll(spec)).containsExactlyInAnyOrder(bob, mary);
+  }
+
+  @DisplayName("Or 在任何順位都得到相同的結果")
+  @Test
+  void permutationInvariance() {
+    var expected = List.of(bob, mary);
+    assertThat(repository.findAll(new Conjunction<>(List.of(new Or<>(nameIsBob), genderIsFemale))))
+        .containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(repository.findAll(new Conjunction<>(List.of(genderIsFemale, new Or<>(nameIsBob)))))
+        .containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @DisplayName("三個元素的所有排列都得到相同的結果")
+  @Test
+  void permutationInvarianceOfThreeElements() {
+    Specification<Customer> or = new Or<>(nameIsBob);
+    var permutations =
+        List.of(
+            List.of(or, genderIsFemale, nameIsMary),
+            List.of(or, nameIsMary, genderIsFemale),
+            List.of(genderIsFemale, or, nameIsMary),
+            List.of(genderIsFemale, nameIsMary, or),
+            List.of(nameIsMary, or, genderIsFemale),
+            List.of(nameIsMary, genderIsFemale, or));
+    // (gender = FEMALE and name = 'mary') or name = 'bob'
+    var expected = List.of(bob, mary);
+    permutations.forEach(
+        specs ->
+            assertThat(repository.findAll(new Conjunction<>(specs)))
+                .as("specs=%s", specs)
+                .containsExactlyInAnyOrderElementsOf(expected));
+  }
+
+  @DisplayName("全部都是 Or 時依然全部以 Or 結合")
+  @Test
+  void allElementsAreOr() {
+    var spec = new Conjunction<>(List.of(new Or<>(nameIsBob), new Or<>(nameIsMary)));
+    assertThat(repository.findAll(spec)).containsExactlyInAnyOrder(bob, mary);
+  }
+
+  @DisplayName("沒有任何元素時不產生 Predicate")
+  @Test
+  void noElement() {
+    assertThat(repository.findAll(new Conjunction<Customer>(List.of())))
+        .containsExactlyInAnyOrder(matt, bob, mary);
+  }
+}

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/DisjunctionTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/DisjunctionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2022 SoftLeader
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package tw.com.softleader.data.jpa.spec.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import tw.com.softleader.data.jpa.spec.IntegrationTest;
+import tw.com.softleader.data.jpa.spec.usecase.Customer;
+import tw.com.softleader.data.jpa.spec.usecase.CustomerRepository;
+import tw.com.softleader.data.jpa.spec.usecase.Gender;
+
+@IntegrationTest
+class DisjunctionTest {
+
+  @Autowired CustomerRepository repository;
+
+  Customer matt;
+  Customer bob;
+  Customer mary;
+
+  Specification<Customer> nameIsBob;
+  Specification<Customer> genderIsMale;
+  Specification<Customer> nameIsMary;
+
+  @BeforeEach
+  void setup() {
+    matt = repository.save(Customer.builder().name("matt").gender(Gender.MALE).build());
+    bob = repository.save(Customer.builder().name("bob").gender(Gender.MALE).build());
+    mary = repository.save(Customer.builder().name("mary").gender(Gender.FEMALE).build());
+
+    nameIsBob = new Equals<>(noopContext(), "name", "bob");
+    genderIsMale = new Equals<>(noopContext(), "gender", Gender.MALE);
+    nameIsMary = new Equals<>(noopContext(), "name", "mary");
+  }
+
+  @DisplayName("combine 沒有 Wrapper 的元素時使用 Or")
+  @Test
+  void combineWithoutWrapper() {
+    var disjunction = new Disjunction<Customer>(List.of());
+    var combined = disjunction.combine(genderIsMale, nameIsMary);
+    assertThat(repository.findAll(combined)).containsExactlyInAnyOrder(matt, bob, mary);
+  }
+
+  @DisplayName("combine 有 And Wrapper 的元素時使用 And")
+  @Test
+  void combineWithAndWrapper() {
+    var disjunction = new Disjunction<Customer>(List.of());
+    var combined = disjunction.combine(genderIsMale, new And<>(nameIsBob));
+    assertThat(repository.findAll(combined)).containsExactly(bob);
+  }
+
+  @DisplayName("overridesOperator 只認得 And")
+  @Test
+  void overridesOperator() {
+    var disjunction = new Disjunction<Customer>(List.of());
+    assertThat(disjunction.overridesOperator(new And<>(nameIsBob))).isTrue();
+    assertThat(disjunction.overridesOperator(new Or<>(nameIsBob))).isFalse();
+    assertThat(disjunction.overridesOperator(nameIsBob)).isFalse();
+  }
+
+  @DisplayName("第一順位的 And 不會被忽略")
+  @Test
+  void andOnFirstPositionIsNotIgnored() {
+    var spec = new Disjunction<>(List.of(new And<>(genderIsMale), nameIsBob));
+    assertThat(repository.findAll(spec)).containsExactly(bob);
+  }
+
+  @DisplayName("And 在任何順位都得到相同的結果")
+  @Test
+  void permutationInvariance() {
+    var expected = List.of(bob);
+    assertThat(repository.findAll(new Disjunction<>(List.of(new And<>(genderIsMale), nameIsBob))))
+        .containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(repository.findAll(new Disjunction<>(List.of(nameIsBob, new And<>(genderIsMale)))))
+        .containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @DisplayName("三個元素的所有排列都得到相同的結果")
+  @Test
+  void permutationInvarianceOfThreeElements() {
+    Specification<Customer> and = new And<>(genderIsMale);
+    var permutations =
+        List.of(
+            List.of(and, nameIsBob, nameIsMary),
+            List.of(and, nameIsMary, nameIsBob),
+            List.of(nameIsBob, and, nameIsMary),
+            List.of(nameIsBob, nameIsMary, and),
+            List.of(nameIsMary, and, nameIsBob),
+            List.of(nameIsMary, nameIsBob, and));
+    // (name = 'bob' or name = 'mary') and gender = MALE
+    var expected = List.of(bob);
+    permutations.forEach(
+        specs ->
+            assertThat(repository.findAll(new Disjunction<>(specs)))
+                .as("specs=%s", specs)
+                .containsExactlyInAnyOrderElementsOf(expected));
+  }
+
+  @DisplayName("全部都是 And 時依然全部以 And 結合")
+  @Test
+  void allElementsAreAnd() {
+    var spec = new Disjunction<>(List.of(new And<>(genderIsMale), new And<>(nameIsBob)));
+    assertThat(repository.findAll(spec)).containsExactly(bob);
+  }
+
+  @DisplayName("沒有任何元素時不產生 Predicate")
+  @Test
+  void noElement() {
+    assertThat(repository.findAll(new Disjunction<Customer>(List.of())))
+        .containsExactlyInAnyOrder(matt, bob, mary);
+  }
+}


### PR DESCRIPTION
Closes #193

## Problem

`CompoundSpecification.toPredicate` folded its specs with a **seedless** `specs.stream().reduce(this::combine)`. `combine(result, element)` only ever inspects the *element*'s wrapper, so the first-declared spec — which becomes the accumulator — never had its `@Or`/`@And` wrapper examined.

The same annotation therefore produced opposite SQL depending purely on field declaration position:

| criteria fields | before | after |
| --- | --- | --- |
| `[@Or nickname, name]` | `nickname AND name` (the `@Or` silently dropped) | `name OR nickname` |
| `[name, @Or nickname]` | `name OR nickname` | `name OR nickname` |

Mirrored for a field-level `@And` under a class-level `@Or` (`Disjunction`).

## Changes

- **`CompoundSpecification`** (COR-15/COR-16) — before reducing, the fold now *stably* sorts elements that override the compound's default operator to the end. The accumulator is then always a default-operator element, so no wrapper is ever ignored. Composition becomes **permutation invariant**: any declaration order of the same annotated fields yields the same predicate.
- **`CompoundSpecification`** (MAINT-08) — `specs` field and the `Conjunction`/`Disjunction` constructors narrowed from `Collection` to `List`, making the ordered fold an explicit contract rather than a dependency on an unspecified iteration order. All existing call sites (`SpecMapper`, `JoinSpecificationResolver`, `JoinFetchSpecificationResolver`) already pass a `List`, so no caller changed.
- **`Conjunction` / `Disjunction`** — new `overridesOperator(element)` hook expressing which wrapper flips the default operator; `combine` is now defined in terms of it, so the two stay in sync.
- **`SimpleSpecificationResolver`** (MAINT-09) — a field carrying both `@And` and `@Or` now fails fast with a descriptive `IllegalArgumentException` naming the offending class and field, instead of silently resolving to `And`.

## Verification

- `make test` green — **119** mapper + **15** starter tests, 0 failures (JDK 17, the project's declared target).
- New tests (TEST-09), all of which **fail without the fold fix** — verified by temporarily removing the sort, which produced 9 failures:
  - `ConjunctionTest` / `DisjunctionTest` (8 tests each) — direct unit tests for `combine` and `overridesOperator`; first-position wrapper honored; two-element and exhaustive three-element permutation-invariance assertions over real query result sets; all-wrapped and empty-spec edge cases.
  - `SimpleSpecificationResolverTest` — `forceOr3` / `forceAnd2` pin a first-position `@Or` under class-level AND and a first-position `@And` under class-level OR; `forceOrIsPermutationInvariant` / `forceAndIsPermutationInvariant` assert every declaration order of the same criteria returns the same rows; `andOrAreMutuallyExclusive` pins the new fail-fast.

## ⚠️ Behavior change / release note

**Previously-ignored first-position `@Or`/`@And` wrappers now take effect, so affected consumers' result sets change.** This is a bug fix restoring the annotations' documented semantics — a first-position `@Or` that used to be silently dropped now actually ORs.

The existing `forceOr2` test is the concrete illustration: `[name, @Or birthday, gender]` previously folded to `(name OR birthday) AND gender` and returned 2 rows; it now folds to `(name AND gender) OR birthday` and returns 3 rows — the same result as its permutation `forceOr` (`[name, gender, @Or birthday]`), which was already returning 3. Its assertion was updated accordingly, and that update *is* the regression proof for COR-15.

Two notes for reviewers:

1. The `Collection` → `List` narrowing of the public `Conjunction`/`Disjunction` constructors is source-incompatible for anyone constructing them directly with a non-`List` `Collection`. Per the plan this is framed as a fix rather than a breaking change, so no `BREAKING CHANGE:` footer was added — flagging it in case you'd rather it drive a major bump.
2. `NestedSpecificationResolver` has the same silent `@And`-wins behavior as MAINT-09, but it sits outside this work package's scope and was deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
