### PR TITLE
fix(mapper): validate join machinery instead of silently mis-resolving

### DIFF
--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/SpecJoinContext.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/SpecJoinContext.java
@@ -23,11 +23,14 @@ package tw.com.softleader.data.jpa.spec;
 import static java.util.Collections.synchronizedMap;
 import static java.util.Optional.ofNullable;
 
+import jakarta.persistence.criteria.Fetch;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Root;
 import java.lang.annotation.Annotation;
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 import lombok.NonNull;
 import org.springframework.lang.Nullable;
 import tw.com.softleader.data.jpa.spec.domain.JoinContext;
@@ -38,8 +41,23 @@ import tw.com.softleader.data.jpa.spec.domain.JoinContext;
 class SpecJoinContext implements JoinContext {
 
   private final Map<HandleKey, Object> handled = synchronizedMap(new HashMap<>());
-  private final Map<JoinKey, Join<?, ?>> joined = synchronizedMap(new HashMap<>());
-  private final Map<FetchKey, FetchRef> fetched = synchronizedMap(new HashMap<>());
+
+  /*
+   * Join and fetch bookkeeping belongs to the single query execution that created it: a reused
+   * Specification is executed against a brand new Root every time, so entries kept per Root would
+   * pile up for as long as that Specification lives.
+   *
+   * The Root is therefore a weak key, which lets an entry die together with the criteria tree it
+   * describes. The criteria nodes kept as values refer back to their Root, so they are held weakly
+   * as well - a strong value would keep its own key reachable and defeat the weak key entirely
+   * (see the WeakHashMap javadoc). That is safe because a Root owns every join and fetch built
+   * from it, which keeps the referents alive for as long as the execution can still reach them.
+   */
+  private final Map<Root<?>, Map<String, WeakReference<Join<?, ?>>>> joined =
+      synchronizedMap(new WeakHashMap<>());
+
+  private final Map<Root<?>, Map<String, FetchEntry>> fetched =
+      synchronizedMap(new WeakHashMap<>());
 
   @Override
   public boolean hasHandled(
@@ -54,22 +72,34 @@ class SpecJoinContext implements JoinContext {
 
   @Override
   public void putIfAbsent(@NonNull Root<?> root, @NonNull String alias, @NonNull Join<?, ?> join) {
-    joined.putIfAbsent(new JoinKey(root, alias), join);
+    byAlias(joined, root).putIfAbsent(alias, new WeakReference<>(join));
   }
 
   @Override
   public void putIfAbsent(@NonNull Root<?> root, @NonNull String alias, @NonNull FetchRef ref) {
-    fetched.putIfAbsent(new FetchKey(root, alias), ref);
+    byAlias(fetched, root)
+        .putIfAbsent(alias, new FetchEntry(new WeakReference<>(ref.fetch()), ref.paths()));
   }
 
   @Override
   public Join<?, ?> getJoin(@NonNull Root<?> root, @NonNull String alias) {
-    return joined.get(new JoinKey(root, alias));
+    return ofNullable(joined.get(root))
+        .map(aliases -> aliases.get(alias))
+        .map(WeakReference::get)
+        .orElse(null);
   }
 
   @Override
   public FetchRef getFetch(@NonNull Root<?> root, @NonNull String alias) {
-    return fetched.get(new FetchKey(root, alias));
+    return ofNullable(fetched.get(root))
+        .map(aliases -> aliases.get(alias))
+        .map(FetchEntry::toRef)
+        .orElse(null);
+  }
+
+  private static <V> Map<String, V> byAlias(
+      @NonNull Map<Root<?>, Map<String, V>> byRoot, @NonNull Root<?> root) {
+    return byRoot.computeIfAbsent(root, key -> synchronizedMap(new HashMap<>()));
   }
 
   record HandleKey(@NonNull String target, @Nullable String field, @NonNull Annotation def) {
@@ -82,7 +112,11 @@ class SpecJoinContext implements JoinContext {
     }
   }
 
-  record JoinKey(@NonNull Root<?> root, @NonNull String alias) {}
+  record FetchEntry(@NonNull WeakReference<Fetch<?, ?>> fetch, @NonNull String[] paths) {
 
-  record FetchKey(@NonNull Root<?> root, @NonNull String alias) {}
+    @Nullable
+    FetchRef toRef() {
+      return ofNullable(fetch.get()).map(f -> new FetchRef(f, paths)).orElse(null);
+    }
+  }
 }

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Join.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/Join.java
@@ -25,6 +25,7 @@ import static tw.com.softleader.data.jpa.spec.domain.JoinContext.CTX_JOIN;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -81,7 +82,9 @@ public class Join<T> implements Specification<T> {
   public Predicate toPredicate(
       @NonNull Root<T> root, @Nullable CriteriaQuery<?> query, @NonNull CriteriaBuilder builder) {
     if (query != null) {
-      query.distinct(distinct);
+      // accumulate rather than overwrite: every join contributes to the query, so a join declared
+      // with distinct=false must not silently undo the distinct=true of an earlier one
+      query.distinct(query.isDistinct() || distinct);
     }
     join(root);
     return null;
@@ -89,17 +92,23 @@ public class Join<T> implements Specification<T> {
 
   private void join(Root<T> root) {
     var jc = context.getAs(CTX_JOIN, JoinContext.class);
-
-    // check if alias already exists, skip creating a new join
-    if (jc.getJoin(root, alias) != null) {
-      return;
-    }
+    var existing = jc.getJoin(root, alias);
 
     if (!pathToJoinOn.contains(".")) {
+      // alias already exists, reuse it as long as it stands for the very same join
+      if (existing != null) {
+        verifyNoConflict(existing, root, pathToJoinOn);
+        return;
+      }
       jc.putIfAbsent(root, alias, root.join(pathToJoinOn, joinType));
       return;
     }
     var byDot = pathToJoinOn.split("\\.");
+    if (byDot.length != 2) {
+      throw new IllegalArgumentException(
+          "Join path: '%s' (alias: '%s') consists of %d segments, but a join path is limited to 2 segments in the form of '<parent-alias>.<association>'! Define an intermediate join for each additional segment and refer to its alias here."
+              .formatted(pathToJoinOn, alias, byDot.length));
+    }
 
     var extractedAlias = byDot[0];
     var joined = jc.getJoin(root, extractedAlias);
@@ -110,6 +119,30 @@ public class Join<T> implements Specification<T> {
     }
 
     var extractedPathToJoin = byDot[1];
+    // alias already exists, reuse it as long as it stands for the very same join
+    if (existing != null) {
+      verifyNoConflict(existing, joined, extractedPathToJoin);
+      return;
+    }
     jc.putIfAbsent(root, alias, joined.join(extractedPathToJoin, joinType));
+  }
+
+  private void verifyNoConflict(
+      @NonNull jakarta.persistence.criteria.Join<?, ?> existing,
+      @NonNull From<?, ?> parent,
+      @NonNull String attributeName) {
+    if (existing.getParent() == parent
+        && existing.getAttribute().getName().equals(attributeName)
+        && existing.getJoinType() == joinType) {
+      return;
+    }
+    throw new IllegalArgumentException(
+        "Conflicting join definitions share the alias: '%s'! It is already defined as a %s join on the attribute: '%s', so it can not be redefined as a %s join on the path: '%s'. Every join alias must be declared with the same path and joinType."
+            .formatted(
+                alias,
+                existing.getJoinType(),
+                existing.getAttribute().getName(),
+                joinType,
+                pathToJoinOn));
   }
 }

--- a/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/SimpleSpecification.java
+++ b/mapper/src/main/java/tw/com/softleader/data/jpa/spec/domain/SimpleSpecification.java
@@ -27,6 +27,7 @@ import static tw.com.softleader.data.jpa.spec.domain.JoinContext.CTX_JOIN;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Root;
 import java.lang.reflect.InvocationTargetException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.StringJoiner;
 import lombok.Builder;
@@ -98,26 +99,57 @@ public abstract class SimpleSpecification<T> implements Specification<T> {
   }
 
   private Path<?> getExpr(@NonNull Root<T> root, @NonNull String field) {
-    return getJoin(root, field).or(() -> getFetch(root, field)).orElseGet(() -> root.get(field));
+    return getJoin(root, field)
+        .or(() -> getFetch(root, field))
+        .orElseGet(() -> getAttribute(root, field));
   }
 
   @SuppressWarnings({"unchecked"})
   private Optional<Path<T>> getJoin(@NonNull Root<T> root, @NonNull String field) {
-    return ofNullable(context.getAs(CTX_JOIN, JoinContext.class).getJoin(root, field))
-        .map(joined -> (Path<T>) joined);
+    return ofNullable(joinContext().getJoin(root, field)).map(joined -> (Path<T>) joined);
   }
 
   private Optional<Path<T>> getFetch(@NonNull Root<T> root, @NonNull String field) {
-    return ofNullable(context.getAs(CTX_JOIN, JoinContext.class).getFetch(root, field))
-        .map(ref -> getFetchPath(root, ref));
+    return ofNullable(joinContext().getFetch(root, field)).map(ref -> getFetchPath(root, ref));
   }
 
+  @SuppressWarnings({"unchecked"})
   private Path<T> getFetchPath(@NonNull Root<T> root, @NonNull FetchRef ref) {
+    // Resolve through the fetch node itself, since it carries the joinType the fetch was declared
+    // with. Re-navigating the paths from the root would emit an implicit inner join instead, so a
+    // non-INNER @JoinFetch would restrict the content query differently from the count query -
+    // which resolves the very same alias as a real join - and page totals would disagree with the
+    // page content.
+    if (ref.fetch() instanceof Path<?> fetched) {
+      return (Path<T>) fetched;
+    }
     Path<T> current = root;
     for (var path : ref.paths()) {
       current = current.get(path);
     }
     return current;
+  }
+
+  private Path<T> getAttribute(@NonNull Root<T> root, @NonNull String field) {
+    try {
+      return root.get(field);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException(
+          "Unable to resolve: '%s' of the path: '%s'! It is neither a join alias registered on this query nor an attribute of %s. If '%s' is meant to be a join alias, make sure the @Join or @JoinFetch defining it is declared before this spec - declaration order matters, and a join declared on a null-valued field is never applied."
+              .formatted(field, path, root.getJavaType().getSimpleName(), field),
+          e);
+    }
+  }
+
+  private JoinContext joinContext() {
+    try {
+      return context.getAs(CTX_JOIN, JoinContext.class);
+    } catch (NoSuchElementException e) {
+      throw new IllegalStateException(
+          "No JoinContext registered under the context key: '%s'! Resolving the multi-segment path: '%s' needs the join registry that SpecMapper populates while it builds the specification, so build this spec through SpecMapper.toSpec(..) instead of constructing it directly."
+              .formatted(CTX_JOIN, path),
+          e);
+    }
   }
 
   @Override

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/JoinFetchSpecificationResolverTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/JoinFetchSpecificationResolverTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.Mockito.spy;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.JoinType;
 import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,12 +35,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import tw.com.softleader.data.jpa.spec.annotation.JoinFetch;
 import tw.com.softleader.data.jpa.spec.annotation.JoinFetch.JoinFetches;
 import tw.com.softleader.data.jpa.spec.annotation.Spec;
 import tw.com.softleader.data.jpa.spec.domain.Conjunction;
 import tw.com.softleader.data.jpa.spec.domain.Equals;
 import tw.com.softleader.data.jpa.spec.domain.In;
+import tw.com.softleader.data.jpa.spec.domain.IsNull;
 import tw.com.softleader.data.jpa.spec.domain.Like;
 import tw.com.softleader.data.jpa.spec.usecase.*;
 
@@ -350,6 +353,28 @@ class JoinFetchSpecificationResolverTest {
     assertThat(root.getFetches()).hasSize(1);
   }
 
+  @DisplayName("非 INNER 的 JoinFetch, count 與 content 應以相同的 join 語意解析 alias")
+  @Test
+  void nonInnerJoinFetchShouldKeepCountAndContentInSync() {
+    repository.save(
+        Customer.builder().name("matt").order(Order.builder().itemName("Pizza").build()).build());
+    // bob 沒有任何 order, 只有 LEFT JOIN 才找得到他
+    var bob = repository.save(Customer.builder().name("bob").build());
+
+    var criteria = LeftJoinFetchOnField.builder().withoutItem(true).build();
+
+    var spec = mapper.toSpec(criteria, Customer.class);
+
+    var content = repository.findAll(spec);
+    assertThat(content).containsExactly(bob);
+    assertThat(repository.count(spec)).isEqualTo(content.size());
+
+    // page size 1 讓 Spring Data 無法省略 count query
+    var page = repository.findAll(spec, PageRequest.of(0, 1));
+    assertThat(page.getTotalElements()).isEqualTo(content.size());
+    assertThat(page.getContent()).containsExactly(bob);
+  }
+
   @JoinFetch(path = "orders")
   @AllArgsConstructor
   @Data
@@ -417,5 +442,14 @@ class JoinFetchSpecificationResolverTest {
     @JoinFetch(path = "orders", alias = "order")
     @Spec(path = "order.itemName", value = Like.class)
     String itemName;
+  }
+
+  @Builder
+  @Data
+  public static class LeftJoinFetchOnField {
+
+    @JoinFetch(path = "orders", alias = "o", joinType = JoinType.LEFT)
+    @Spec(path = "o.itemName", value = IsNull.class)
+    Boolean withoutItem;
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/JoinSpecificationResolverTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/JoinSpecificationResolverTest.java
@@ -21,10 +21,12 @@
 package tw.com.softleader.data.jpa.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.Mockito.spy;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.JoinType;
 import java.util.Collection;
 import lombok.Builder;
 import lombok.Data;
@@ -305,6 +307,129 @@ class JoinSpecificationResolverTest {
     assertThat(root.getJoins()).hasSize(1);
   }
 
+  @DisplayName("多個 Join 的 distinct 應累加, 不應被最後執行的 Join 覆寫")
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void distinctShouldBeAccumulatedAcrossJoins() {
+
+    var spec = mapper.toSpec(new MixedDistinctJoinsOnClassOnly(), Customer.class);
+
+    var cb = entityManager.getCriteriaBuilder();
+    var query = cb.createQuery(Customer.class);
+    var root = query.from(Customer.class);
+
+    spec.toPredicate(root, query, cb);
+
+    assertThat(query.isDistinct()).isTrue();
+  }
+
+  @DisplayName("相同 alias 但 path 不同的 Join 應拋出例外")
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void conflictingPathOnSameAliasShouldThrow() {
+
+    var criteria = ConflictingPathAliasOnField.builder().orderId(1L).badgeId(2L).build();
+
+    var spec = mapper.toSpec(criteria, Customer.class);
+
+    var cb = entityManager.getCriteriaBuilder();
+    var query = cb.createQuery(Customer.class);
+    var root = query.from(Customer.class);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> spec.toPredicate(root, query, cb))
+        .withMessageContaining("shared")
+        .withMessageContaining("orders")
+        .withMessageContaining("badges");
+  }
+
+  @DisplayName("相同 alias 但 joinType 不同的 Join 應拋出例外")
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void conflictingJoinTypeOnSameAliasShouldThrow() {
+
+    var criteria = ConflictingJoinTypeAliasOnField.builder().orderId(1L).itemName("Pizza").build();
+
+    var spec = mapper.toSpec(criteria, Customer.class);
+
+    var cb = entityManager.getCriteriaBuilder();
+    var query = cb.createQuery(Customer.class);
+    var root = query.from(Customer.class);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> spec.toPredicate(root, query, cb))
+        .withMessageContaining("order")
+        .withMessageContaining(JoinType.INNER.name())
+        .withMessageContaining(JoinType.LEFT.name());
+  }
+
+  @DisplayName("超過兩層的 Join path 應拋出例外")
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void joinPathWithMoreThanTwoSegmentsShouldThrow() {
+
+    var spec = mapper.toSpec(new ThreeSegmentJoinPathOnClassOnly(), Customer.class);
+
+    var cb = entityManager.getCriteriaBuilder();
+    var query = cb.createQuery(Customer.class);
+    var root = query.from(Customer.class);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> spec.toPredicate(root, query, cb))
+        .withMessageContaining("o.tags.name")
+        .withMessageContaining("3 segments")
+        .withMessageContaining("2 segments");
+  }
+
+  @DisplayName("Spec 參照到未註冊的 join alias 應拋出例外, 而不是靜默地查 root 的同名屬性")
+  @Test
+  @SuppressWarnings("DataFlowIssue")
+  void unregisteredJoinAliasShouldThrow() {
+
+    // orderId 為 null, 因此定義在它身上的 join 不會被套用, alias 'o' 也就不會被註冊
+    var criteria = NullValuedJoinAliasOnField.builder().itemName("Pizza").build();
+
+    var spec = mapper.toSpec(criteria, Customer.class);
+
+    var cb = entityManager.getCriteriaBuilder();
+    var query = cb.createQuery(Customer.class);
+    var root = query.from(Customer.class);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> spec.toPredicate(root, query, cb))
+        .withMessageContaining("o.itemName")
+        .withMessageContaining("declared before this spec")
+        .withMessageContaining("null-valued field");
+  }
+
+  @DisplayName("重複使用同一個 Specification 執行多次, 結果應一致")
+  @Test
+  void reusedSpecificationShouldStayConsistentAcrossExecutions() {
+    var matt =
+        repository.save(
+            Customer.builder()
+                .name("matt")
+                .order(Order.builder().itemName("Pizza").build())
+                .build());
+    var mary =
+        repository.save(
+            Customer.builder()
+                .name("mary")
+                .order(Order.builder().itemName("Hamburger").build())
+                .build());
+    repository.save(
+        Customer.builder().name("bob").order(Order.builder().itemName("Coke").build()).build());
+
+    var criteria = SingleJoinOnField.builder().item("Pizza").item("Hamburger").build();
+
+    var spec = mapper.toSpec(criteria, Customer.class);
+
+    for (var execution = 0; execution < 3; execution++) {
+      assertThat(repository.findAll(spec)).hasSize(2).contains(matt, mary);
+      assertThat(repository.count(spec)).isEqualTo(2);
+    }
+  }
+
   @Builder
   @Data
   public static class SingleJoinOnField {
@@ -363,6 +488,52 @@ class JoinSpecificationResolverTest {
 
     @Join(path = "orders", alias = "order")
     @Spec(path = "order.itemName", value = Like.class)
+    String itemName;
+  }
+
+  @Join(path = "orders", alias = "o", distinct = true)
+  @Join(path = "badges", alias = "b", distinct = false)
+  public static class MixedDistinctJoinsOnClassOnly {}
+
+  @Join(path = "orders", alias = "o")
+  @Join(path = "o.tags.name", alias = "deep")
+  public static class ThreeSegmentJoinPathOnClassOnly {}
+
+  @Builder
+  @Data
+  public static class ConflictingPathAliasOnField {
+
+    @Join(path = "orders", alias = "shared")
+    @Spec(path = "shared.id")
+    Long orderId;
+
+    @Join(path = "badges", alias = "shared")
+    @Spec(path = "shared.id")
+    Long badgeId;
+  }
+
+  @Builder
+  @Data
+  public static class ConflictingJoinTypeAliasOnField {
+
+    @Join(path = "orders", alias = "order")
+    @Spec(path = "order.id")
+    Long orderId;
+
+    @Join(path = "orders", alias = "order", joinType = JoinType.LEFT)
+    @Spec(path = "order.itemName", value = Like.class)
+    String itemName;
+  }
+
+  @Builder
+  @Data
+  public static class NullValuedJoinAliasOnField {
+
+    @Join(path = "orders", alias = "o")
+    @Spec(path = "o.id")
+    Long orderId;
+
+    @Spec(path = "o.itemName")
     String itemName;
   }
 }

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/SpecJoinContextTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/SpecJoinContextTest.java
@@ -20,15 +20,28 @@
  */
 package tw.com.softleader.data.jpa.spec;
 
+import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static tw.com.softleader.data.jpa.spec.SpecJoinContext.HandleKey.identityHex;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.Root;
 import java.lang.annotation.Annotation;
+import java.lang.ref.WeakReference;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import tw.com.softleader.data.jpa.spec.SpecJoinContext.HandleKey;
+import tw.com.softleader.data.jpa.spec.domain.JoinContext.FetchRef;
+import tw.com.softleader.data.jpa.spec.usecase.Customer;
 
+@IntegrationTest
 class SpecJoinContextTest {
+
+  @Autowired EntityManager entityManager;
 
   @Test
   void shouldConvertTargetAndFieldToIdentityHex() throws NoSuchFieldException {
@@ -98,6 +111,36 @@ class SpecJoinContextTest {
 
     assertThat(key1).isNotEqualTo(key2);
     assertThat(key1.field()).isNotEqualTo(key2.field());
+  }
+
+  @DisplayName("join/fetch 的登錄資料應隨著 Root 一起被回收, 不應無限累積")
+  @Test
+  void shouldNotRetainBookkeepingOfCollectedRoot() {
+    var context = new SpecJoinContext();
+    var cb = entityManager.getCriteriaBuilder();
+
+    var query = cb.createQuery(Customer.class);
+    Root<Customer> root = query.from(Customer.class);
+    context.putIfAbsent(root, "o", root.join("orders"));
+    context.putIfAbsent(root, "b", new FetchRef(root.fetch("badges"), "badges"));
+
+    assertThat(context.getJoin(root, "o")).isNotNull();
+    assertThat(context.getFetch(root, "b")).isNotNull();
+
+    var collected = new WeakReference<>(root);
+    // 放掉這次執行所建立的 criteria tree
+    root = null;
+    query = null;
+
+    await()
+        .atMost(ofSeconds(10))
+        .untilAsserted(
+            () -> {
+              System.gc();
+              assertThat(collected.get()).isNull();
+              assertThat(context).extracting("joined", MAP).isEmpty();
+              assertThat(context).extracting("fetched", MAP).isEmpty();
+            });
   }
 
   static class TargetA {

--- a/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/yet_another_package/ConstructSimpleSpecificationTest.java
+++ b/mapper/src/test/java/tw/com/softleader/data/jpa/spec/domain/yet_another_package/ConstructSimpleSpecificationTest.java
@@ -20,15 +20,19 @@
  */
 package tw.com.softleader.data.jpa.spec.domain.yet_another_package;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
 import static tw.com.softleader.data.jpa.spec.IntegrationTest.TestApplication.noopContext;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.util.NoSuchElementException;
 import lombok.NonNull;
 import org.junit.jupiter.api.Test;
+import tw.com.softleader.data.jpa.spec.SpecContext;
 import tw.com.softleader.data.jpa.spec.domain.Context;
 import tw.com.softleader.data.jpa.spec.domain.SimpleSpecification;
 
@@ -84,6 +88,33 @@ class ConstructSimpleSpecificationTest {
                     .path("")
                     .value(new Object())
                     .build());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void multiSegmentPathWithoutJoinContextShouldExplainTheMapperPipeline() {
+    // 直接 new 出來的 spec, 其 Context 不會有 SpecMapper 放進去的 JoinContext
+    var spec = new DottedPathSpec(new SpecContext(), "o.itemName", new Object());
+    Root<Object> root = mock(Root.class);
+
+    assertThatIllegalStateException()
+        .isThrownBy(() -> spec.toPredicate(root, null, mock(CriteriaBuilder.class)))
+        .withMessageContaining("o.itemName")
+        .withMessageContaining("SpecMapper.toSpec")
+        .withCauseInstanceOf(NoSuchElementException.class);
+  }
+
+  public static class DottedPathSpec extends SimpleSpecification<Object> {
+
+    DottedPathSpec(@NonNull Context context, @NonNull String path, @NonNull Object value) {
+      super(context, path, value);
+    }
+
+    @Override
+    public Predicate toPredicate(Root root, CriteriaQuery query, CriteriaBuilder criteriaBuilder) {
+      getPath(root);
+      return null;
+    }
   }
 
   public static class ProtectedConstructorSpec extends SimpleSpecification<Object> {


### PR DESCRIPTION
Closes #198

**WP3 — Join machinery.** The cluster's root cause was shared: the join resolvers assumed well-formed, well-ordered input and silently mis-handled anything else. One pass, validate-or-fail-loud.

## Findings

| Finding | What changed | How it was verified |
| --- | --- | --- |
| **COR-05** — `query.distinct()` last-writer-wins | `Join.toPredicate` now accumulates: `query.distinct(query.isDistinct() \|\| distinct)`, so a join declared `distinct=false` can no longer undo an earlier `distinct=true`. | `distinctShouldBeAccumulatedAcrossJoins` — two class-level joins with opposing flags; asserts `query.isDistinct()`. Fails on `jakarta` (flag ends up `false`). |
| **COR-06** — conflicting definitions sharing an alias silently dropped | When the alias is already registered, `Join` compares the stored join's **parent**, **attribute name** and **joinType** against the new definition and throws `IllegalArgumentException` naming the alias, the existing joinType + attribute, and the conflicting joinType + path. Identical redefinitions still reuse the existing join (existing dedup behaviour preserved). | `conflictingPathOnSameAliasShouldThrow` (`orders` vs `badges` on alias `shared`) and `conflictingJoinTypeOnSameAliasShouldThrow` (`INNER` vs `LEFT` on alias `order`). Both fail on `jakarta` (no exception). |
| **COR-07** — dotted path drops segments after the second | `Join` validates `byDot.length == 2` and throws, citing the actual segment count and the two-segment `'<parent-alias>.<association>'` limit, with the advice to define an intermediate join. | `joinPathWithMoreThanTwoSegmentsShouldThrow` (`o.tags.name`). Fails on `jakarta` — it silently joined `o.tags`. |
| **COR-10** — unregistered alias silently falls back to `root.get(alias)` | `SimpleSpecification.getExpr` routes the fallback through `getAttribute(..)`, which wraps any provider failure in an `IllegalArgumentException` naming the segment, the full path, the entity, and the declaration-order requirement (including that a join on a null-valued field is never applied). | `unregisteredJoinAliasShouldThrow` — reproduces the finding exactly: the `@Join` sits on a **null-valued** field so alias `o` is never registered, while a second field references `o.itemName`. Fails on `jakarta` (opaque Hibernate `PathElementException`). |
| **COR-11** — count and content resolve a `@JoinFetch` alias with different join semantics | `getFetchPath` resolves through the fetch node itself (a `Path` in Hibernate), which carries the declared `joinType`, instead of re-navigating `root.get(..)` — which emitted an implicit **inner** join. Content and count now agree. Falls back to the old path-walk if a provider's `Fetch` is not a `Path`. | `nonInnerJoinFetchShouldKeepCountAndContentInSync` — `LEFT` `@JoinFetch` + `IsNull` on the joined column, with a customer that has no orders. On `jakarta` the content query returned `[]` while `count` returned `1`; now both find him, and the page assertion uses `PageRequest.of(0, 1)` so Spring Data cannot skip the count query. |
| **MAINT-04** — bare `NoSuchElementException` on direct construction | `SimpleSpecification` resolves `CTX_JOIN` through `joinContext()`, which translates the missing key into an `IllegalStateException` explaining that multi-segment paths need the registry `SpecMapper` populates, with the original exception as cause. | `multiSegmentPathWithoutJoinContextShouldExplainTheMapperPipeline` — directly-constructed spec with a dotted path over an empty `SpecContext`. |
| **PERF-02** — `joined`/`fetched` grow per execution of a reused Specification | `SpecJoinContext` now keys both maps **weakly by `Root`**, so bookkeeping dies with the criteria tree that owns it. The criteria nodes stored as values reference their `Root`, so they are held weakly too — a strong value would keep its own key reachable and defeat the weak key entirely. That is safe because Hibernate's `AbstractSqmFrom` owns every join and fetch built from it (`addSqmJoin`), keeping the referents alive for as long as the execution can reach them. No size cap. | `shouldNotRetainBookkeepingOfCollectedRoot` — registers a join and a fetch, drops the criteria tree, and asserts under `await()` that both maps empty out once the `Root` is collected. Fails on `jakarta` (times out; entries never clear). Ran 3× for flakiness. Plus `reusedSpecificationShouldStayConsistentAcrossExecutions` as a functional regression guard. |
| **TEST-04** — no coverage of join edge/error paths | 9 new tests across `JoinSpecificationResolverTest`, `JoinFetchSpecificationResolverTest`, `SpecJoinContextTest` and `ConstructSimpleSpecificationTest`. | 8 of the 9 were confirmed **discriminating**: with `mapper/src/main` reverted to `jakarta` and only the new tests applied, all 8 fail. The 9th is a deliberate regression guard that passes on both. |

## Release note

**Tightened validation — several silent-wrong-result paths now throw.** Configurations that previously produced a quietly incorrect query now fail fast:

- two `@Join` declarations sharing an alias but differing in path or `joinType` → `IllegalArgumentException`
- a join `path` with more than two dot-separated segments → `IllegalArgumentException`
- a `@Spec` path whose first segment is neither a registered join alias nor an entity attribute → `IllegalArgumentException` (previously fell back to a same-named attribute on the root)
- a `SimpleSpecification` with a multi-segment path constructed outside `SpecMapper` → `IllegalStateException` (previously a bare `NoSuchElementException`)

Also behavioural: `distinct` now accumulates across joins rather than being decided by the last join executed, and predicates on a non-INNER `@JoinFetch` alias now use the declared join type in the content query, so page totals match page content.

## Verification

`make test` green — **107** mapper tests + **15** starter tests, 0 failures. Run on Temurin **17.0.6** (the project's declared `java.version`; the machine default resolves to JDK 25, switched via SDKMAN for the build only — no pom changes).

## Deliberately not done

- **`JoinFetch.java` is outside this work package's file allowlist**, so two things were left alone even though they touch the same findings:
  - `JoinFetch.toPredicate` still calls `query.distinct(distinct)` **unconditionally** — the COR-05 last-writer-wins hazard survives for `@JoinFetch`, and for criteria that mix `@Join` with `@JoinFetch`. The `Join` side is fixed, and count queries inherit the fix through the delegation, but the content-query path in `JoinFetch` needs the same one-line change. **Worth a follow-up issue** — same finding, sibling class.
  - `JoinFetch.fetch(..)` has the COR-07 twin (no `byDot.length` validation) and the COR-06 twin (early return without comparing the stored definition).
- **#192 (WP2) boundary:** `shouldDelegateToJoin` / `delegatePredicateToJoin` were not touched. COR-11 was fixed entirely on the **resolution** side in `SimpleSpecification`, so the count query's semantics are unchanged and nothing here collides with WP2's redesign of the delegation.
- **COR-10 keeps the `root.get(field)` fallback** rather than throwing on every unregistered alias. Throwing unconditionally would break legitimate nested *attribute* paths (`@Spec(path = "address.city")`), which are indistinguishable from aliases at this layer — the registry records aliases only at `toPredicate` time and carries no record of which aliases were *declared*. Making the fallback's failure loud and descriptive is the strongest check available without changing the `JoinContext` interface (also outside the allowlist). One residual case stays silent: an alias that collides with a real attribute name (e.g. the default alias of `@Join(path = "orders")` is `orders`) still resolves to that attribute when the join was not applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
