### PR TITLE
fix(ci): notify on jakarta build failures instead of dead main guard

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,10 @@ spec:
     }
     failure {
       script {
-        if (env.BRANCH_NAME == 'main'
+        // BRANCH_IS_PRIMARY 由 multibranch 的 branch-api 在 SCM 預設分支上設為 'true',
+        // 不必隨預設分支改名而改這裡; 非 multibranch job 不會有這個變數, 故 fallback 比對分支名
+        def isPrimaryBranch = env.BRANCH_IS_PRIMARY == 'true' || env.BRANCH_NAME == 'jakarta'
+        if (isPrimaryBranch
             // 若短時間太密集的 push, 之前的 job 會被 jenkins 中斷，這樣就可能會就連第一步都還沒執行的狀況，但也算是失敗
             // 然而取得 git 資訊就在第一步，所以至少要第一步都有執行完才發佈 slack 吧
             && env.LAST_COMMIT_AUTHOR_NAME && env.LAST_COMMIT_AUTHOR_EMAIL && env.LAST_COMMIT_TIME) {


### PR DESCRIPTION
Refs #197 (COR-02 only)

## 問題

`Jenkinsfile` 的失敗通知守衛寫死在 `BRANCH_NAME == 'main'`，但這個 repo 的預設分支與作用線是 `jakarta`，該條件永遠不成立——**`jakarta` 上的 build 失敗從來沒有通知過任何人**。

## 改動

守衛改為 `env.BRANCH_IS_PRIMARY == 'true' || env.BRANCH_NAME == 'jakarta'`：

- `BRANCH_IS_PRIMARY` 由 multibranch 的 branch-api 在 SCM 預設分支上設為 `'true'`，之後預設分支若改名不必再回來改這裡；
- 非 multibranch job 沒有這個變數，故保留分支名字面比對作為 fallback。

`Jenkinsfile` 單檔，+4/-1。

## 與 #206 的關係

本 PR 從 #206 抽出 COR-02 這一項單獨處理。#206 另外兩項經評估後決定不做：

- **TEST-01（新增 GitHub Actions build gate）** — 與既有 Jenkins build 功能重疊，同一份測試跑兩次；
- **DEP-02（第三方 action SHA 釘選）** — 維護成本相對於本 repo 的風險輪廓不划算。

#206 將關閉，理由記錄於該 PR 與 #197。

## 驗證

Jenkins pipeline 語法無法在本機執行，改動本身是單一條件式重寫、不涉及 Java 原始碼，未跑 `make test`。實際生效需待合併後由 `jakarta` 上一次真實的 build 失敗驗證。